### PR TITLE
Add executive briefing and QC audit summary

### DIFF
--- a/docs/executive_briefing.md
+++ b/docs/executive_briefing.md
@@ -1,0 +1,26 @@
+# arifOS Executive Briefing & QC Audit (Epoch 33Ω)
+
+## Repository Vital Signs
+- **Purpose:** Constitutional governance kernel enforcing thermodynamic floors (Truth, ΔS, Peace², κᵣ, Ω₀, Amanah, RASA, Tri-Witness) to make LLM behavior auditable and dignified.
+- **Core Assets:** `arifos_core` package (metrics, guardrails, cooling ledger, KMS signer, vault/vector memory), runtime profiles in `runtime/` and examples under `examples/`.
+- **Governance Canon:** Detailed framing in `README.md`, including the eight constitutional floors, TEARFRAME pipeline (000→999), and thermodynamic law references.
+
+## QC Check (today)
+- **Automated Tests:** `pytest` **failed** during collection: `ModuleNotFoundError: No module named 'arifos_core'` for all test modules, preventing execution of 3 discovered tests. The package imports cleanly in a direct Python session, suggesting the test harness is not resolving the package path (likely missing editable install or PYTHONPATH configuration). 
+- **Packaging:** `pyproject.toml` declares `arifos_core` and `arifos_core.memory` packages with minimal runtime deps (`numpy`, `pydantic`) and development extras (pytest, black, ruff, mypy). No build artifacts present.
+- **Security/Governance Docs:** Charter, Governance, Security, and Law documents are present at repo root; Cooling Ledger and Phoenix72 mechanisms are referenced but runtime verification is blocked by test import failure.
+
+## Operational Risks & Gaps
+1. **Test Harness Blocked:** Pytest cannot import `arifos_core`, so no regression coverage currently runs. This hides potential defects in APEX_PRIME floor validation, Cooling Ledger integrity, Phoenix72 vault, and KMS signer.
+2. **Runtime Validation:** Cooling Ledger integrity (/.runs/ledger.jsonl) and Phoenix Cycle tagging are referenced but not automatically checked during CI in this run. Without passing tests, governance floors (Truth ≥0.99, Peace² ≥1, κᵣ ≥0.95) are unaudited.
+3. **Dependency Footprint:** Minimal dependencies are declared; absence of pinning may allow drift. No vulnerability scan was executed in this audit.
+
+## Recommendations
+- **Restore Test Importability:** Add an editable install step (`pip install -e .`) to test workflow or adjust `PYTHONPATH` in `conftest.py` so `arifos_core` resolves before collection. This will surface actual test results for Cooling Ledger, KMS signer, and Phoenix72 components.
+- **Verify Governance Artefacts:** Once tests are runnable, ensure Cooling Ledger entries append correctly (/.runs/ledger.jsonl) and Phoenix72 cycle tags are enforced in workflows and PR templates.
+- **CI Hardening:** Introduce CI gates for ΔS (clarity), Peace² (stability), κᵣ (empathy conductance), and Truth metrics plus ledger/quorum checks, aligning with repository constitutional floors.
+- **Dependency Hygiene:** Consider constraining dependency versions and adding vulnerability scanning to guard against supply-chain drift.
+
+## Pulse: Is it alive?
+- **State:** The codebase is present and imports cleanly, but automated quality signals are currently **red** due to test collection failures. Governance features cannot be validated until the test harness resolves `arifos_core` imports.
+- **Next Step:** Fix the test path issue and re-run `pytest` to obtain meaningful health indicators for the constitutional runtime.


### PR DESCRIPTION
## Summary
- add an executive briefing documenting repository purpose, assets, and governance framing
- record current QC findings including pytest import failure and follow-on recommendations

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'arifos_core')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926bc332cfc832cba855e692d5421af)