### PR TITLE
888_FIX: Align MCP endpoint path and domain to aaamcp.arif-fazil.com/mcp

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -4,14 +4,14 @@
 Railway deployment failing → Now works with guaranteed health check
 
 ## 🌐 Your Domain
-**https://arifos.arif-fazil.com/** ← Still works! No changes needed.
+**https://aaamcp.arif-fazil.com/** ← Still works! No changes needed.
 
 ## 📦 What Was Created
 `standalone_sse_server.py` - A bulletproof MCP server with zero complex dependencies
 
 ## 🧪 Quick Test (After Deploy)
 ```bash
-curl https://arifos.arif-fazil.com/health
+curl https://aaamcp.arif-fazil.com/health
 ```
 Should return `{"status": "healthy", ...}`
 
@@ -20,7 +20,7 @@ Should return `{"status": "healthy", ...}`
 
 ## 📊 What to Monitor
 1. Railway Dashboard → Should show "Active"
-2. Domain → https://arifos.arif-fazil.com/health
+2. Domain → https://aaamcp.arif-fazil.com/health
 3. Tools → All 5 Trinity tools available
 
 ## 🔄 If Something Goes Wrong

--- a/codebase/mcp/README.md
+++ b/codebase/mcp/README.md
@@ -133,7 +133,7 @@ aaa-mcp-sse
 # Headers: MCP-Protocol-Version: 2025-11-25
 ```
 
-**Live public endpoint:** `https://arif-fazil.com/mcp`
+**Live public endpoint:** `https://aaamcp.arif-fazil.com/mcp`
 
 ---
 
@@ -380,7 +380,7 @@ mypy codebase/mcp/ --ignore-missing-imports
 curl http://localhost:8000/health
 
 # Production
-curl https://arif-fazil.com/health
+curl https://aaamcp.arif-fazil.com/health
 ```
 
 **Expected response:**

--- a/codebase/mcp/transports/sse.py
+++ b/codebase/mcp/transports/sse.py
@@ -114,7 +114,7 @@ class SSETransport(BaseTransport):
                     "status": "ONLINE",
                     "version": "v55.2-AAA",
                     "message": "DITEMPA BUKAN DIBERI",
-                    "endpoints": {"health": "/health", "metrics": "/metrics/json", "mcp": "/sse"},
+                    "endpoints": {"health": "/health", "metrics": "/metrics/json", "mcp": "/mcp"},
                 }
             )
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # API Reference — MCP Tools v53
 
-**Endpoint:** `https://arif-fazil.com/mcp`
+**Endpoint:** `https://aaamcp.arif-fazil.com/mcp`
 **Protocol:** MCP 2024-11-05+ (Streamable HTTP) with SSE fallback
 **Transport:** JSON-RPC 2.0 over stdio (local) or HTTP (deployed)
 

--- a/docs/CODEX_SETUP.md
+++ b/docs/CODEX_SETUP.md
@@ -30,7 +30,7 @@ Create or edit your Codex config file:
   "mcpServers": {
     "arifos-aaa": {
       "name": "AAA MCP",
-      "url": "https://arif-fazil.com/mcp",
+      "url": "https://aaamcp.arif-fazil.com/mcp",
       "transport": "streamable-http"
     }
   }
@@ -44,7 +44,7 @@ Create or edit your Codex config file:
 codex mcp list
 
 # Expected output:
-# ✅ arifos-aaa - https://arif-fazil.com/mcp
+# ✅ arifos-aaa - https://aaamcp.arif-fazil.com/mcp
 ```
 
 ### Step 4: Use with Codex
@@ -124,7 +124,7 @@ Every interaction through Codex now has:
 
 ```bash
 # Test endpoint manually
-curl https://arif-fazil.com/health
+curl https://aaamcp.arif-fazil.com/health
 
 # Should return:
 # {"status": "healthy", "tools": 7, "architecture": "AAA-7CORE-v53.2.7"}
@@ -142,7 +142,7 @@ codex mcp tools arifos-aaa
 ```bash
 # Remove and re-add
 codex mcp remove arifos-aaa
-codex mcp add arifos-aaa https://arif-fazil.com/mcp
+codex mcp add arifos-aaa https://aaamcp.arif-fazil.com/mcp
 ```
 
 ---
@@ -162,8 +162,8 @@ codex mcp add arifos-aaa https://arif-fazil.com/mcp
 ## Links
 
 - **Dashboard**: https://arif-fazil.com/dashboard
-- **Health**: https://arif-fazil.com/health
+- **Health**: https://aaamcp.arif-fazil.com/health
 - **GitHub**: https://github.com/ariffazil/arifOS
-- **MCP Endpoint**: https://arif-fazil.com/mcp
+- **MCP Endpoint**: https://aaamcp.arif-fazil.com/mcp
 
 **DITEMPA BUKAN DIBERI** — Your code is now constitutionally governed.

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -45,10 +45,10 @@ numReplicas = 1
 
 | URL | Purpose |
 |-----|---------|
-| `https://arif-fazil.com/health` | Health check |
-| `https://arif-fazil.com/mcp` | MCP protocol endpoint |
-| `https://arif-fazil.com/dashboard` | Live telemetry |
-| `https://arif-fazil.com/metrics/json` | JSON metrics |
+| `https://aaamcp.arif-fazil.com/health` | Health check |
+| `https://aaamcp.arif-fazil.com/mcp` | MCP protocol endpoint |
+| `https://aaamcp.arif-fazil.com/dashboard` | Live telemetry |
+| `https://aaamcp.arif-fazil.com/metrics/json` | JSON metrics |
 
 ---
 
@@ -161,7 +161,7 @@ Kimi connects via SSE transport to the deployed server.
 ### Connection
 
 ```
-MCP Endpoint: https://arif-fazil.com/mcp
+MCP Endpoint: https://aaamcp.arif-fazil.com/mcp
 Transport: SSE / Streamable HTTP
 ```
 
@@ -174,7 +174,7 @@ See `mcp/kimi/kimi_config.yaml` for adapter configuration.
 ChatGPT Developer Mode and OpenAI Codex connect via HTTP:
 
 ```
-MCP URL: https://arif-fazil.com/mcp
+MCP URL: https://aaamcp.arif-fazil.com/mcp
 Transport: Streamable HTTP (JSON-RPC 2.0)
 ```
 
@@ -197,7 +197,7 @@ Tools are auto-discovered via `tools/list`.
 All deployments should verify health:
 
 ```bash
-curl https://arif-fazil.com/health
+curl https://aaamcp.arif-fazil.com/health
 # {"status":"healthy","version":"v53.2.8-CODEBASE-AAA7","mode":"CODEBASE","transport":"streamable-http","tools":7}
 ```
 

--- a/docs/QUICK_START_MCP.md
+++ b/docs/QUICK_START_MCP.md
@@ -100,8 +100,8 @@ Proxy:  ✅ Proxied
 {
   "mcpServers": {
     "arifos-cloud": {
-      "url": "https://mcp.arif-fazil.com/sse",
-      "transport": "sse"
+      "url": "https://aaamcp.arif-fazil.com/mcp",
+      "transport": "streamable-http"
     }
   }
 }
@@ -109,7 +109,7 @@ Proxy:  ✅ Proxied
 
 ### 6. Test
 ```bash
-curl https://mcp.arif-fazil.com/health
+curl https://aaamcp.arif-fazil.com/health
 ```
 
 ✅ **Done!** Cloud MCP server running.

--- a/docs/platforms/chatgpt_dev.md
+++ b/docs/platforms/chatgpt_dev.md
@@ -13,7 +13,7 @@ Integrate arifOS constitutional governance directly into ChatGPT's Developer Mod
 1. **ChatGPT Plus** or **Enterprise** account
 2. **Developer Mode** enabled (Settings → Features → Developer Mode)
 3. Access to arifOS MCP server (choose one):
-   - **Cloud:** `https://arifos.arif-fazil.com` (managed)
+   - **Cloud:** `https://aaamcp.arif-fazil.com` (managed)
    - **Self-hosted:** Docker/Railway deployment (see [Deployment](#deployment) below)
 
 ---
@@ -24,12 +24,12 @@ ChatGPT only supports **HTTP/SSE transport** (not stdio). You need a publicly ac
 
 ### Option A: Use Managed arifOS (Fastest)
 
-**URL:** `https://arifos.arif-fazil.com`
+**URL:** `https://aaamcp.arif-fazil.com`
 
 **Endpoints:**
-- Health: `https://arifos.arif-fazil.com/health`
-- MCP: `https://arifos.arif-fazil.com/mcp` (ChatGPT Actions)
-- SSE: `https://arifos.arif-fazil.com/sse` (Claude Desktop compatible)
+- Health: `https://aaamcp.arif-fazil.com/health`
+- MCP: `https://aaamcp.arif-fazil.com/mcp` (ChatGPT Actions)
+- SSE: `https://aaamcp.arif-fazil.com/sse` (Claude Desktop compatible)
 
 **Pros:**
 - ✅ Zero setup
@@ -44,7 +44,7 @@ ChatGPT only supports **HTTP/SSE transport** (not stdio). You need a publicly ac
 
 **Test the endpoint:**
 ```bash
-curl https://arifos.arif-fazil.com/health
+curl https://aaamcp.arif-fazil.com/health
 ```
 
 Expected response:
@@ -196,7 +196,7 @@ Create `arifos-openapi.json`:
   },
   "servers": [
     {
-      "url": "https://arifos.arif-fazil.com",
+      "url": "https://aaamcp.arif-fazil.com",
       "description": "Production MCP Server"
     }
   ],
@@ -334,7 +334,7 @@ description: |
   Returns SEAL (approved), SABAR (warning), or VOID (blocked) verdict.
   Provides cryptographic audit trails for compliance.
 
-url: https://arifos.arif-fazil.com  # Or your self-hosted URL
+url: https://aaamcp.arif-fazil.com  # Or your self-hosted URL
 
 # OpenAPI Spec
 openapi: |
@@ -381,8 +381,8 @@ Write a Python function to reverse a string
       {
         "name": "constitutional_validation",
         "description": "Validate response against 13 constitutional floors",
-        "url": "https://arifos.arif-fazil.com/messages",
-        "openapi_spec": "https://arifos.arif-fazil.com/openapi.json"
+        "url": "https://aaamcp.arif-fazil.com/messages",
+        "openapi_spec": "https://aaamcp.arif-fazil.com/openapi.json"
       }
     ],
     "conversation_starters": [
@@ -677,7 +677,7 @@ What is the exact population of Malaysia as of today?
 {
   "mcpServers": {
     "arifos": {
-      "url": "https://arifos.arif-fazil.com",
+      "url": "https://aaamcp.arif-fazil.com",
       "env": {
         "ARIFOS_RATE_LIMIT_PER_MINUTE": "50",
         "ARIFOS_RATE_LIMIT_PER_HOUR": "500"
@@ -697,7 +697,7 @@ For stricter governance（e．g．，financial advice）：
 {
   "mcpServers": {
     "arifos": {
-      "url": "https://arifos.arif-fazil.com",
+      "url": "https://aaamcp.arif-fazil.com",
       "env": {
         "ARIFOS_SEAL_RATE_TARGET": "0.90",
         "ARIFOS_DISABLED_FLOORS": ""
@@ -717,7 +717,7 @@ For faster iteration（testing only，NOT production）：
 {
   "mcpServers": {
     "arifos": {
-      "url": "https://arifos.arif-fazil.com",
+      "url": "https://aaamcp.arif-fazil.com",
       "env": {
         "ARIFOS_PHYSICS_DISABLED": "1",        // F4：entropy
         "ARIFOS_DISABLED_FLOORS": "F6,F13"     // Skip humility，curiosity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,8 +202,8 @@ Repository = "https://github.com/ariffazil/arifOS"
 Issues = "https://github.com/ariffazil/arifOS/issues"
 Changelog = "https://github.com/ariffazil/arifOS/blob/main/CHANGELOG.md"
 "Live Server" = "https://arif-fazil.com/"
-"Health Check" = "https://arif-fazil.com/health"
-"MCP Endpoint" = "https://arif-fazil.com/mcp"
+"Health Check" = "https://aaamcp.arif-fazil.com/health"
+"MCP Endpoint" = "https://aaamcp.arif-fazil.com/mcp"
 
 [tool.setuptools]
 include-package-data = true

--- a/templates/claude_desktop_config.json
+++ b/templates/claude_desktop_config.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "arifos-production": {
-      "url": "https://arifos.arif-fazil.com/sse",
+      "url": "https://aaamcp.arif-fazil.com/mcp",
       "disabled": false,
       "alwaysAllow": [
         "mcp_000_init",


### PR DESCRIPTION
Root endpoint incorrectly advertised /sse as MCP path — FastMCP
streamable_http_app() serves on /mcp. Updated all client-facing
configs and docs from old domains (arif-fazil.com, arifos.arif-fazil.com,
mcp.arif-fazil.com) to canonical aaamcp.arif-fazil.com/mcp.

https://claude.ai/code/session_013uT5HbngwPaBUAM6bBAKfv