### PR TITLE
fix: MCP SSE deployment — health endpoint + HTTPS proxy headers

### DIFF
--- a/aaa_mcp/__main__.py
+++ b/aaa_mcp/__main__.py
@@ -50,7 +50,21 @@ def main():
         port = int(os.getenv("PORT", 8080))
         host = os.getenv("HOST", "0.0.0.0")
         print(f"[arifOS] Starting MCP server with SSE transport on {host}:{port}", file=sys.stderr)
-        mcp.run(transport="sse", host=host, port=port)
+
+        # Railway terminates TLS at proxy and sets X-Forwarded-Proto.
+        # We need uvicorn to trust these headers so SSE endpoint
+        # advertises https:// URLs, not http://.
+        import uvicorn
+        from fastmcp.server.http import create_sse_app
+
+        app = create_sse_app(mcp, message_path="/messages", sse_path="/sse")
+        uvicorn.run(
+            app,
+            host=host,
+            port=port,
+            proxy_headers=True,
+            forwarded_allow_ips="*",
+        )
         return
 
     if mode in ("http", "streamable-http"):

--- a/aaa_mcp/rest.py
+++ b/aaa_mcp/rest.py
@@ -405,7 +405,8 @@ async def apex_judge_wrapper(request: Request):
 async def sse_endpoint(request: Request):
     """MCP SSE transport endpoint."""
     async def event_generator() -> AsyncGenerator[str, None]:
-        msg_url = f"{request.url.scheme}://{request.url.netloc}/messages"
+        scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+        msg_url = f"{scheme}://{request.url.netloc}/messages"
         yield f"event: endpoint\ndata: {msg_url}\n\n"
         
         while True:

--- a/aaa_mcp/server.py
+++ b/aaa_mcp/server.py
@@ -320,30 +320,19 @@ async def get_floor_spec(floor_id: str) -> str:
 # HEALTH CHECK ENDPOINT
 # =============================================================================
 
-from starlette.requests import Request
-from starlette.responses import JSONResponse
 
-
-# Health check mounted on MCP's Starlette app for Railway monitoring
-# NOTE: FastMCP 2.x+ supports mcp.app, 1.x does not
-try:
-    # Try FastMCP 2.x style
-    @mcp.app.get("/health")
-    async def health_check(request: Request):
-        """Health check endpoint for Railway and load balancers."""
-        return JSONResponse({
-            "status": "healthy",
-            "service": "aaa-mcp",
-            "version": "64.2.0",
-            "transport": "sse",
-            "timestamp": time.time()
-        })
-except AttributeError:
-    # FastMCP 1.x - health check not supported, server still runs
-    # Railway health check will need to use a different method
-    health_check = None
-    import logging
-    logging.warning("FastMCP 1.x detected - /health endpoint not available. Consider upgrading to 2.x.")
+# Health check using FastMCP 2.x custom_route API
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request):
+    """Health check endpoint for Railway and load balancers."""
+    from starlette.responses import JSONResponse
+    return JSONResponse({
+        "status": "healthy",
+        "service": "aaa-mcp",
+        "version": "64.2.0",
+        "transport": "sse",
+        "timestamp": time.time()
+    })
 
 
 # =============================================================================


### PR DESCRIPTION
- Replace broken @mcp.app.get("/health") with @mcp.custom_route() (FastMCP 2.x API)
- Use create_sse_app() with uvicorn proxy_headers=True so SSE endpoint
  advertises https:// URLs behind Railway's TLS-terminating proxy
- Fix rest.py SSE endpoint to respect x-forwarded-proto header

https://claude.ai/code/session_01AWsnQQJCQmaMXiZw95x8Q7