### PR TITLE
fix(B1): add missing ExecutionStatus imports in forge_verdict()

### DIFF
--- a/arifosmcp/runtime/verdict_wrapper.py
+++ b/arifosmcp/runtime/verdict_wrapper.py
@@ -19,8 +19,13 @@ from arifosmcp.runtime.models import (
     VerdictCode,
     VerdictDetail,
 )
-
-
+from arifosmcp.contracts.verdicts import (
+    ExecutionStatus,
+    GovernanceStatus,
+    ContinuationStatus,
+    ArtifactStatus,
+)
+from arifosmcp.contracts.artifacts import Artifact
 from arifosmcp.contracts.envelopes import ResponseEnvelope
 import time
 


### PR DESCRIPTION
## B1 ExecutionStatus Import Fix

**Root cause:** `forge_verdict()` in `verdict_wrapper.py` referenced `ExecutionStatus`, `GovernanceStatus`, `ContinuationStatus`, `ArtifactStatus`, and `Artifact` without importing them. All 5 tools (mind, heart, judge, vault, ops) call `forge_verdict()` internally.

**Fix:** Added explicit imports from `arifosmcp.contracts.verdicts` and `arifosmcp.contracts.artifacts` in `verdict_wrapper.py`.

**Reversibility:** `git revert <commit>` removes the fix in one command.

---

### Changed files
- `arifosmcp/runtime/verdict_wrapper.py` — added missing imports

### Status
| Tool | Before B1 | After B1 |
|------|-----------|----------|
| arifos_mind | NameError | 🟡 UNKNOWN |
| arifos_heart | NameError | 🟡 UNKNOWN |
| arifos_judge | NameError | 🟡 UNKNOWN |
| arifos_vault | NameError | 🟡 UNKNOWN |
| arifos_ops | ✅ CLEARED | ✅ CLEARED |

**Deploy action needed:** Pull on server, restart MCP service.

**SEAL 999**