### PR TITLE
feat: add HTTP adapter, Copilot Studio contract, and law capsule

### DIFF
--- a/arifos_http_adapter.py
+++ b/arifos_http_adapter.py
@@ -222,11 +222,14 @@ def _call_mcp_stdio(tool_name: str, arguments: dict[str, Any], timeout_seconds: 
     module_name = _env_str(MCP_MODULE_ENV, "arifosmcp.runtime")
     transport_mode = _env_str(MCP_TRANSPORT_ENV, "stdio")
 
-    env = os.environ.copy()
-    env.setdefault("ARIFOS_MINIMAL_STDIO", "1")
+    # Filtered environment: avoid leaking parent secrets to child process
+    env_whitelist = {"PATH", "SYSTEMROOT", "ARIFOS_MINIMAL_STDIO", "PYTHONPATH"}
+    filtered_env = {k: v for k, v in os.environ.items() if k in env_whitelist}
+    filtered_env.setdefault("ARIFOS_MINIMAL_STDIO", "1")
     py_path = os.getenv(MCP_PYTHONPATH_ENV, "").strip()
     if py_path:
-        env["PYTHONPATH"] = py_path
+        filtered_env["PYTHONPATH"] = py_path
+    env = filtered_env
 
     proc = subprocess.Popen(
         [python_exe, "-m", module_name, transport_mode],
@@ -335,16 +338,19 @@ def _decode_mcp_tool_result(tool_response: dict[str, Any] | None) -> tuple[bool,
     content = result.get("content")
 
     if isinstance(content, list):
+        text_parts: list[str] = []
         for block in content:
             if isinstance(block, dict) and block.get("type") == "text":
                 text = block.get("text", "")
-                if not isinstance(text, str):
-                    continue
-                try:
-                    parsed = json.loads(text)
-                except Exception:
-                    parsed = text
-                return is_error, parsed
+                if isinstance(text, str):
+                    text_parts.append(text)
+        if text_parts:
+            full_text = "\n".join(text_parts)
+            try:
+                parsed = json.loads(full_text)
+            except Exception:
+                parsed = full_text
+            return is_error, parsed
 
     return is_error, result
 

--- a/arifos_http_adapter.py
+++ b/arifos_http_adapter.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import secrets
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel, Field
+
+
+APP_NAME = "arifOS HTTP Adapter"
+APP_VERSION = "0.1.0"
+
+# Security: token must be provided via environment variable.
+AUTH_TOKEN_ENV = "ARIFOS_ADAPTER_TOKEN"
+
+# Runtime command defaults to local arifOS stdio server.
+MCP_PYTHON_EXE_ENV = "ARIFOS_MCP_PYTHON"
+MCP_MODULE_ENV = "ARIFOS_MCP_MODULE"
+MCP_TRANSPORT_ENV = "ARIFOS_MCP_TRANSPORT"
+MCP_TIMEOUT_ENV = "ARIFOS_MCP_TIMEOUT_SECONDS"
+MCP_PYTHONPATH_ENV = "ARIFOS_MCP_PYTHONPATH"
+
+# Side-effecting tools that require explicit ratification.
+SIDE_EFFECT_TOOLS_ENV = "ARIFOS_SIDE_EFFECT_TOOLS"
+DEFAULT_SIDE_EFFECT_TOOLS = {
+    "arifos_forge",
+    "arifos_repo_seal",
+    "arifos_memory",  # can write in vector_store mode
+    "arifos_vault",   # immutable append/write
+}
+
+
+class ToolCallRequest(BaseModel):
+    name: str = Field(min_length=1)
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    humanRatified: bool = False
+    requestId: str | int | None = None
+    confirmationStep: bool = False
+    approvalUx: str = Field(default="none", pattern="^(none|manual-confirmation|adaptive-card)$")
+    retryOnVoid: str = Field(default="prompt-confirmation", pattern="^(stop|prompt-confirmation|retry-once-after-confirmation)$")
+
+
+class McpContent(BaseModel):
+    type: str = "text"
+    text: str
+
+
+class McpStyleResponse(BaseModel):
+    content: list[McpContent]
+    isError: bool
+
+
+@dataclass
+class RpcResult:
+    init_response: dict[str, Any] | None
+    tool_response: dict[str, Any] | None
+    stderr: str
+
+
+app = FastAPI(title=APP_NAME, version=APP_VERSION)
+
+
+COPILOT_STUDIO_CONTRACT = {
+    "contractVersion": "1.0",
+    "actionName": "arifos_tools_call",
+    "description": "Copilot Studio -> arifOS adapter contract with explicit human ratification gate",
+    "confirmationStep": {
+        "requiredForSideEffectTools": True,
+        "inputField": "confirmationStep",
+        "meaning": "User explicitly confirmed execution in UX before adapter execution",
+    },
+    "approvalUx": {
+        "inputField": "approvalUx",
+        "allowedValues": ["none", "manual-confirmation", "adaptive-card"],
+        "default": "none",
+    },
+    "retryBehaviorOnVoid": {
+        "inputField": "retryOnVoid",
+        "allowedValues": ["stop", "prompt-confirmation", "retry-once-after-confirmation"],
+        "default": "prompt-confirmation",
+        "notes": "Adapter returns retry guidance in VOID payload; caller controls actual retry loop.",
+    },
+}
+
+
+LAW_CAPSULE = {
+    "capsuleVersion": "1.0",
+    "scope": "arifOS HTTP adapter boundary",
+    "intent": "Prevent overclaim by separating doctrine, runtime-enforced guards, and human-process expectations.",
+    "LAW": [
+        {
+            "id": "LAW-001",
+            "title": "Human sovereignty for side effects",
+            "statement": "Side-effecting actions require explicit human ratification in this operating mode.",
+        },
+        {
+            "id": "LAW-002",
+            "title": "Copilot Studio confirmation gate",
+            "statement": "Confirmation UX must be completed before side-effecting execution.",
+        },
+        {
+            "id": "LAW-003",
+            "title": "MCP-style response discipline",
+            "statement": "Adapter responses for tool execution must use content[] and isError framing.",
+        },
+    ],
+    "EXPECTATION": [
+        {
+            "id": "EXP-001",
+            "statement": "Human operator validates intent before setting humanRatified=true.",
+            "owner": "human-operator",
+        },
+        {
+            "id": "EXP-002",
+            "statement": "Copilot Studio flow handles VOID retry policy correctly and avoids automatic unsafe retries.",
+            "owner": "copilot-studio-flow",
+        },
+        {
+            "id": "EXP-003",
+            "statement": "Deployment keeps ARIFOS_ADAPTER_TOKEN secret-managed and rotated by enterprise policy.",
+            "owner": "platform-ops",
+        },
+    ],
+}
+
+
+def _env_str(name: str, default: str) -> str:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    value = value.strip()
+    return value if value else default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _get_side_effect_tools() -> set[str]:
+    raw = os.getenv(SIDE_EFFECT_TOOLS_ENV, "")
+    if not raw.strip():
+        return set(DEFAULT_SIDE_EFFECT_TOOLS)
+    return {token.strip() for token in raw.split(",") if token.strip()}
+
+
+def _mcp_error(text: str) -> McpStyleResponse:
+    return McpStyleResponse(content=[McpContent(text=text)], isError=True)
+
+
+def _mcp_ok(payload: Any) -> McpStyleResponse:
+    if isinstance(payload, str):
+        text = payload
+    else:
+        text = json.dumps(payload, ensure_ascii=True)
+    return McpStyleResponse(content=[McpContent(text=text)], isError=False)
+
+
+def _void_payload(code: str, reason: str, request: ToolCallRequest) -> dict[str, Any]:
+    return {
+        "verdict": "VOID",
+        "code": code,
+        "reason": reason,
+        "tool": request.name,
+        "retry": {
+            "policy": request.retryOnVoid,
+            "allowed": request.retryOnVoid != "stop",
+            "nextStep": "Require explicit user confirmation then resend with humanRatified=true and confirmationStep=true",
+        },
+        "approval": {
+            "humanRatified": request.humanRatified,
+            "confirmationStep": request.confirmationStep,
+            "approvalUx": request.approvalUx,
+        },
+    }
+
+
+def _require_auth(authorization: str | None) -> None:
+    expected = os.getenv(AUTH_TOKEN_ENV, "").strip()
+    if not expected:
+        raise HTTPException(
+            status_code=500,
+            detail="Server auth misconfigured: missing ARIFOS_ADAPTER_TOKEN",
+        )
+
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing Authorization header")
+
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(status_code=401, detail="Authorization must be Bearer token")
+
+    presented = parts[1].strip()
+    if not secrets.compare_digest(presented, expected):
+        raise HTTPException(status_code=403, detail="Invalid bearer token")
+
+
+def _read_stream_lines(pipe, target_queue: queue.Queue[str]) -> None:
+    try:
+        for line in iter(pipe.readline, ""):
+            target_queue.put(line)
+    except Exception:
+        return
+
+
+def _call_mcp_stdio(tool_name: str, arguments: dict[str, Any], timeout_seconds: int) -> RpcResult:
+    python_exe = _env_str(MCP_PYTHON_EXE_ENV, "python")
+    module_name = _env_str(MCP_MODULE_ENV, "arifosmcp.runtime")
+    transport_mode = _env_str(MCP_TRANSPORT_ENV, "stdio")
+
+    env = os.environ.copy()
+    env.setdefault("ARIFOS_MINIMAL_STDIO", "1")
+    py_path = os.getenv(MCP_PYTHONPATH_ENV, "").strip()
+    if py_path:
+        env["PYTHONPATH"] = py_path
+
+    proc = subprocess.Popen(
+        [python_exe, "-m", module_name, transport_mode],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=env,
+    )
+
+    out_q: queue.Queue[str] = queue.Queue()
+    err_q: queue.Queue[str] = queue.Queue()
+
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    threading.Thread(target=_read_stream_lines, args=(proc.stdout, out_q), daemon=True).start()
+    threading.Thread(target=_read_stream_lines, args=(proc.stderr, err_q), daemon=True).start()
+
+    def send(payload: dict[str, Any]) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(payload, ensure_ascii=True) + "\n")
+        proc.stdin.flush()
+
+    def read_by_id(expected_id: int, timeout_s: int) -> dict[str, Any] | None:
+        end = time.time() + timeout_s
+        while time.time() < end:
+            try:
+                line = out_q.get(timeout=0.2)
+            except queue.Empty:
+                continue
+
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+
+            if obj.get("id") == expected_id:
+                return obj
+        return None
+
+    try:
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "arifos-http-adapter", "version": APP_VERSION},
+                },
+            }
+        )
+        init_response = read_by_id(1, timeout_seconds)
+
+        send({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            }
+        )
+        tool_response = read_by_id(2, timeout_seconds)
+
+        stderr_lines: list[str] = []
+        while True:
+            try:
+                stderr_lines.append(err_q.get_nowait())
+            except queue.Empty:
+                break
+
+        return RpcResult(
+            init_response=init_response,
+            tool_response=tool_response,
+            stderr="".join(stderr_lines).strip(),
+        )
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+def _decode_mcp_tool_result(tool_response: dict[str, Any] | None) -> tuple[bool, Any]:
+    if tool_response is None:
+        return True, {"error": "timeout waiting for tools/call response"}
+
+    if "error" in tool_response:
+        return True, tool_response["error"]
+
+    result = tool_response.get("result", {})
+    if not isinstance(result, dict):
+        return True, {"error": "invalid MCP result payload"}
+
+    is_error = bool(result.get("isError"))
+    content = result.get("content")
+
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "")
+                if not isinstance(text, str):
+                    continue
+                try:
+                    parsed = json.loads(text)
+                except Exception:
+                    parsed = text
+                return is_error, parsed
+
+    return is_error, result
+
+
+def _guard_matrix() -> list[dict[str, Any]]:
+    side_effect_tools = sorted(_get_side_effect_tools())
+    token_configured = bool(os.getenv(AUTH_TOKEN_ENV, "").strip())
+    return [
+        {
+            "id": "GRD-001",
+            "title": "Bearer auth required on /tools/call",
+            "enforced": True,
+            "evidence": "_require_auth() raises 401/403 and checks ARIFOS_ADAPTER_TOKEN",
+            "runtimeState": {"authTokenConfigured": token_configured},
+        },
+        {
+            "id": "GRD-002",
+            "title": "Side-effect gate requires humanRatified=true",
+            "enforced": True,
+            "evidence": "tools_call() returns VOID code F13_RATIFICATION_REQUIRED before MCP dispatch",
+            "runtimeState": {"sideEffectTools": side_effect_tools},
+        },
+        {
+            "id": "GRD-003",
+            "title": "Confirmation gate requires confirmationStep=true",
+            "enforced": True,
+            "evidence": "tools_call() returns VOID code CONFIRMATION_REQUIRED before MCP dispatch",
+            "runtimeState": {"appliesTo": side_effect_tools},
+        },
+        {
+            "id": "GRD-004",
+            "title": "VOID includes retry guidance",
+            "enforced": True,
+            "evidence": "_void_payload() always returns retry.policy/allowed/nextStep",
+            "runtimeState": {
+                "allowedPolicies": ["stop", "prompt-confirmation", "retry-once-after-confirmation"],
+            },
+        },
+        {
+            "id": "GRD-005",
+            "title": "MCP-style response shape for /tools/call",
+            "enforced": True,
+            "evidence": "response_model=McpStyleResponse with content[] and isError",
+            "runtimeState": {"outputSchema": "McpStyleResponse"},
+        },
+    ]
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    token_set = bool(os.getenv(AUTH_TOKEN_ENV, "").strip())
+    return {
+        "ok": True,
+        "service": APP_NAME,
+        "version": APP_VERSION,
+        "authConfigured": token_set,
+        "mcpModule": _env_str(MCP_MODULE_ENV, "arifosmcp.runtime"),
+        "transport": _env_str(MCP_TRANSPORT_ENV, "stdio"),
+    }
+
+
+@app.get("/contract/copilot-studio")
+def copilot_studio_contract() -> dict[str, Any]:
+    return {
+        **COPILOT_STUDIO_CONTRACT,
+        "inputSchema": ToolCallRequest.model_json_schema(),
+        "outputSchema": McpStyleResponse.model_json_schema(),
+    }
+
+
+@app.get("/law/capsule")
+def law_capsule() -> dict[str, Any]:
+    return {
+        **LAW_CAPSULE,
+        "GUARD": _guard_matrix(),
+        "meta": {
+            "service": APP_NAME,
+            "version": APP_VERSION,
+            "boundary": "HTTP adapter only; does not assert guarantees outside this process",
+        },
+    }
+
+
+@app.post("/tools/call", response_model=McpStyleResponse)
+def tools_call(payload: ToolCallRequest, authorization: str | None = Header(default=None)) -> McpStyleResponse:
+    _require_auth(authorization)
+
+    side_effect_tools = _get_side_effect_tools()
+    if payload.name in side_effect_tools:
+        if not payload.humanRatified:
+            return _mcp_error(json.dumps(_void_payload("F13_RATIFICATION_REQUIRED", "F13: humanRatified=true required for side-effect tool", payload), ensure_ascii=True))
+        if not payload.confirmationStep:
+            return _mcp_error(json.dumps(_void_payload("CONFIRMATION_REQUIRED", "Side-effect tool requires confirmationStep=true", payload), ensure_ascii=True))
+
+    timeout_seconds = _env_int(MCP_TIMEOUT_ENV, 20)
+    rpc_result = _call_mcp_stdio(payload.name, payload.arguments, timeout_seconds)
+
+    is_error, decoded_payload = _decode_mcp_tool_result(rpc_result.tool_response)
+
+    if rpc_result.init_response is None:
+        return _mcp_error(
+            {
+                "error": "initialize timeout",
+                "stderr": rpc_result.stderr,
+                "tool": payload.name,
+            }
+        )
+
+    if is_error:
+        return McpStyleResponse(
+            content=[McpContent(text=json.dumps(decoded_payload, ensure_ascii=True))],
+            isError=True,
+        )
+
+    return _mcp_ok(decoded_payload)
+
+
+if __name__ == "__main__":
+    # Local dev run:
+    #   set ARIFOS_ADAPTER_TOKEN=changeme
+    #   set ARIFOS_MCP_PYTHONPATH=C:\path\to\arifOS-main
+    #   python arifos_http_adapter.py
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=8088, log_level="info")

--- a/core/organs/_4_vault.py
+++ b/core/organs/_4_vault.py
@@ -18,12 +18,19 @@ import secrets
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
-
-import blake3
+try:
+    import blake3
+    _HAS_BLAKE3 = True
+except ModuleNotFoundError:
+    blake3 = None
+    _HAS_BLAKE3 = False
 
 from core.shared.types import HashChain, SealRecord, VaultOutput, Verdict
 
 logger = logging.getLogger(__name__)
+
+if not _HAS_BLAKE3:
+    logger.warning("blake3 not installed; using hashlib.blake2b fallback for vault seal hashes")
 
 # Default storage
 DEFAULT_VAULT_PATH = Path(__file__).parents[2] / "VAULT999" / "vault999.jsonl"
@@ -50,11 +57,14 @@ def _canonical_entry_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def compute_vault_seal_hash(payload: dict[str, Any]) -> str:
-    """Compute the canonical seal hash for a vault entry using blake3."""
+    """Compute the canonical seal hash for a vault entry using blake3 when available."""
     entry_json = json.dumps(
         _canonical_entry_payload(payload), sort_keys=True, separators=(",", ":")
     )
-    return blake3.blake3(entry_json.encode("utf-8")).hexdigest()
+    encoded = entry_json.encode("utf-8")
+    if _HAS_BLAKE3:
+        return blake3.blake3(encoded).hexdigest()
+    return hashlib.blake2b(encoded, digest_size=32).hexdigest()
 
 
 def verify_vault_record(payload: dict[str, Any]) -> tuple[bool, str | None]:
@@ -448,28 +458,29 @@ async def seal(
 
 async def vault(
     operation: str = "seal",
+    session_id: str = "",
+    summary: str = "",
+    verdict: str = "SEAL",
+    approved_by: str | None = None,
+    approval_reference: str | None = None,
+    telemetry: dict[str, Any] | None = None,
+    seal_mode: Literal["final", "provisional", "audit_only"] = "final",
+    auth_context: dict[str, Any] | None = None,
+    expected_prev_hash: str | None = None,
     **kwargs: Any,
-) -> Any:
-    """Unified Vault Interface."""
+) -> VaultOutput:
+    """Router for vault operations."""
     if operation == "seal":
-        return await seal(**kwargs)
-
-    from .unified_memory import vault as memory_vault
-
-    return await memory_vault(operation=operation, **kwargs)
-
-
-# Unified alias
-SealReceipt = SealRecord
-seal_vault = seal
-
-
-__all__ = [
-    "SealReceipt",
-    "compute_vault_seal_hash",
-    "seal",
-    "seal_vault",
-    "vault",
-    "verify_vault_ledger",
-    "verify_vault_record",
-]
+        return await seal(
+            session_id=session_id,
+            summary=summary,
+            verdict=verdict,
+            approved_by=approved_by,
+            approval_reference=approval_reference,
+            telemetry=telemetry,
+            seal_mode=seal_mode,
+            auth_context=auth_context,
+            expected_prev_hash=expected_prev_hash,
+            **kwargs,
+        )
+    raise ValueError(f"Unsupported vault operation: {operation}")

--- a/core/organs/_4_vault.py
+++ b/core/organs/_4_vault.py
@@ -458,29 +458,28 @@ async def seal(
 
 async def vault(
     operation: str = "seal",
-    session_id: str = "",
-    summary: str = "",
-    verdict: str = "SEAL",
-    approved_by: str | None = None,
-    approval_reference: str | None = None,
-    telemetry: dict[str, Any] | None = None,
-    seal_mode: Literal["final", "provisional", "audit_only"] = "final",
-    auth_context: dict[str, Any] | None = None,
-    expected_prev_hash: str | None = None,
     **kwargs: Any,
-) -> VaultOutput:
-    """Router for vault operations."""
+) -> Any:
+    """Unified Vault Interface."""
     if operation == "seal":
-        return await seal(
-            session_id=session_id,
-            summary=summary,
-            verdict=verdict,
-            approved_by=approved_by,
-            approval_reference=approval_reference,
-            telemetry=telemetry,
-            seal_mode=seal_mode,
-            auth_context=auth_context,
-            expected_prev_hash=expected_prev_hash,
-            **kwargs,
-        )
-    raise ValueError(f"Unsupported vault operation: {operation}")
+        return await seal(**kwargs)
+
+    from .unified_memory import vault as memory_vault
+
+    return await memory_vault(operation=operation, **kwargs)
+
+
+# Unified alias
+SealReceipt = SealRecord
+seal_vault = seal
+
+
+__all__ = [
+    "SealReceipt",
+    "compute_vault_seal_hash",
+    "seal",
+    "seal_vault",
+    "vault",
+    "verify_vault_ledger",
+    "verify_vault_record",
+]

--- a/invoke-mcp.ps1
+++ b/invoke-mcp.ps1
@@ -1,0 +1,240 @@
+param(
+    [ValidateSet("tools/list", "tools/call", "raw")]
+    [string]$Mode = "tools/list",
+
+    [string]$ToolName,
+
+    [string]$ArgumentsJson = "{}",
+
+    [string]$RequestJson,
+
+    [string]$PythonExe = "python",
+
+    [string]$RepoRoot = "C:\Users\arif.fazil\OneDrive - PETRONAS\Documents\DOWNLOADS\arifOS-main",
+
+    [int]$TimeoutSeconds = 30,
+
+    [switch]$RawFrames
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function New-McpFrame {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Id,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Method,
+
+        [Parameter(Mandatory = $true)]
+        [object]$Params
+    )
+
+    return [ordered]@{
+        jsonrpc = "2.0"
+        id = $Id
+        method = $Method
+        params = $Params
+    }
+}
+
+function ConvertTo-CompactJson {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Value
+    )
+
+    return ($Value | ConvertTo-Json -Depth 100 -Compress)
+}
+
+function Parse-JsonOrThrow {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Json,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Label
+    )
+
+    try {
+        return $Json | ConvertFrom-Json -Depth 100
+    }
+    catch {
+        throw "$Label is not valid JSON. $($_.Exception.Message)"
+    }
+}
+
+function Build-RequestFrame {
+    if ($Mode -eq "tools/list") {
+        return (New-McpFrame -Id 2 -Method "tools/list" -Params ([ordered]@{}))
+    }
+
+    if ($Mode -eq "tools/call") {
+        if ([string]::IsNullOrWhiteSpace($ToolName)) {
+            throw "ToolName is required when Mode is tools/call."
+        }
+
+        $arguments = Parse-JsonOrThrow -Json $ArgumentsJson -Label "ArgumentsJson"
+        return (New-McpFrame -Id 2 -Method "tools/call" -Params ([ordered]@{
+            name = $ToolName
+            arguments = $arguments
+        }))
+    }
+
+    if ([string]::IsNullOrWhiteSpace($RequestJson)) {
+        throw "RequestJson is required when Mode is raw."
+    }
+
+    $rawRequest = Parse-JsonOrThrow -Json $RequestJson -Label "RequestJson"
+    if (-not $rawRequest.PSObject.Properties.Name.Contains("id")) {
+        throw "Raw request must include an id so the response can be matched."
+    }
+    return $rawRequest
+}
+
+function Invoke-ArifosMcp {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$RequestFrame
+    )
+
+    $initializeFrame = New-McpFrame -Id 1 -Method "initialize" -Params ([ordered]@{
+        protocolVersion = "2025-11-05"
+        capabilities = [ordered]@{}
+        clientInfo = [ordered]@{
+            name = "arifos-powershell-client"
+            version = "1.0"
+        }
+    })
+
+    $initializedNotification = [ordered]@{
+        jsonrpc = "2.0"
+        method = "notifications/initialized"
+        params = [ordered]@{}
+    }
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $PythonExe
+    $psi.Arguments = "-m arifosmcp.runtime stdio"
+    $psi.WorkingDirectory = $RepoRoot
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    $psi.EnvironmentVariables["PYTHONPATH"] = $RepoRoot
+    $psi.EnvironmentVariables["ARIFOS_MINIMAL_STDIO"] = "1"
+
+    $proc = New-Object System.Diagnostics.Process
+    $proc.StartInfo = $psi
+
+    if (-not $proc.Start()) {
+        throw "Failed to start arifOS MCP process."
+    }
+
+    try {
+        foreach ($frame in @($initializeFrame, $initializedNotification, $RequestFrame)) {
+            $proc.StandardInput.WriteLine((ConvertTo-CompactJson -Value $frame))
+        }
+        $proc.StandardInput.Close()
+
+        $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+        $stderrTask = $proc.StandardError.ReadToEndAsync()
+
+        if (-not $proc.WaitForExit($TimeoutSeconds * 1000)) {
+            try {
+                $proc.Kill()
+            }
+            catch {
+            }
+            throw "Timed out waiting for MCP response after $TimeoutSeconds seconds."
+        }
+
+        $stdout = $stdoutTask.GetAwaiter().GetResult()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
+
+        $frames = @()
+        $parseErrors = @()
+
+        foreach ($line in ($stdout -split "`r?`n")) {
+            if ([string]::IsNullOrWhiteSpace($line)) {
+                continue
+            }
+
+            try {
+                $frames += ,($line | ConvertFrom-Json -Depth 100)
+            }
+            catch {
+                $parseErrors += ,([ordered]@{
+                    line = $line
+                    error = $_.Exception.Message
+                })
+            }
+        }
+
+        $requestId = $RequestFrame.id
+        $initResponse = $null
+        $requestResponse = $null
+
+        foreach ($frame in $frames) {
+            if ($null -ne $frame.id -and $frame.id -eq 1) {
+                $initResponse = $frame
+            }
+            if ($null -ne $frame.id -and $frame.id -eq $requestId) {
+                $requestResponse = $frame
+            }
+        }
+
+        $decodedTextJson = $null
+        if ($null -ne $requestResponse -and $null -ne $requestResponse.result -and $null -ne $requestResponse.result.content) {
+            foreach ($contentBlock in $requestResponse.result.content) {
+                if ($contentBlock.type -eq "text" -and -not [string]::IsNullOrWhiteSpace($contentBlock.text)) {
+                    try {
+                        $decodedTextJson = $contentBlock.text | ConvertFrom-Json -Depth 100
+                    }
+                    catch {
+                    }
+                    break
+                }
+            }
+        }
+
+        return [pscustomobject]@{
+            ok = ($null -ne $requestResponse -and $null -eq $requestResponse.error)
+            init = $initResponse
+            response = $requestResponse
+            decodedTextJson = $decodedTextJson
+            stderr = $stderr.Trim()
+            parseErrors = $parseErrors
+            rawStdout = $stdout
+        }
+    }
+    finally {
+        if (-not $proc.HasExited) {
+            try {
+                $proc.Kill()
+            }
+            catch {
+            }
+        }
+        $proc.Dispose()
+    }
+}
+
+$requestFrame = Build-RequestFrame
+$result = Invoke-ArifosMcp -RequestFrame $requestFrame
+
+if ($RawFrames) {
+    $result | ConvertTo-Json -Depth 100
+}
+elseif ($null -ne $result.decodedTextJson) {
+    $result.decodedTextJson | ConvertTo-Json -Depth 100
+}
+elseif ($null -ne $result.response) {
+    $result.response | ConvertTo-Json -Depth 100
+}
+else {
+    $result | ConvertTo-Json -Depth 100
+}

--- a/invoke-mcp.ps1
+++ b/invoke-mcp.ps1
@@ -10,7 +10,7 @@ param(
 
     [string]$PythonExe = "python",
 
-    [string]$RepoRoot = "C:\Users\arif.fazil\OneDrive - PETRONAS\Documents\DOWNLOADS\arifOS-main",
+    [string]$RepoRoot = $PWD,
 
     [int]$TimeoutSeconds = 30,
 


### PR DESCRIPTION
## Summary
Implements the Phase 1-3 bridge hardening for constrained enterprise environments where local stdio MCP remains internal and HTTP is the external integration surface.

### Phase 1 (Adapter)
- Add `arifos_http_adapter.py` (single FastAPI file)
- Add `GET /health`
- Add `POST /tools/call`
- Enforce strict bearer auth (`ARIFOS_ADAPTER_TOKEN`)
- Enforce `humanRatified` for side-effect tools
- Return MCP-style payload shape: `content[]` + `isError`

### Phase 2 (Copilot Studio Contract)
- Add `GET /contract/copilot-studio`
- Publish machine-readable input/output schemas
- Add request fields for:
  - `confirmationStep`
  - `approvalUx`
  - `retryOnVoid`
- Enforce side-effect confirmation gate (`confirmationStep=true`)
- Return deterministic VOID payloads with retry guidance

### Phase 3 (Law Capsule)
- Add `GET /law/capsule`
- Explicit separation:
  - `LAW` (policy)
  - `GUARD` (runtime-enforced controls)
  - `EXPECTATION` (human/process discipline)
- Include guard evidence + runtime state for auditability
- Add explicit boundary note to prevent capability over-claims

### Runtime reliability fix
- Update `core/organs/_4_vault.py` to support missing `blake3` dependency with `hashlib.blake2b` fallback
- Keeps local runtime operable on locked-down environments while preserving deterministic hash behavior

## Additional tooling
- Add `invoke-mcp.ps1` one-shot MCP client helper for local stdio execution and frame handling

## Notes
- This PR is intentionally scoped to bridge/governance surfaces and startup compatibility.
- No local git dependency required for delivery (API-based branch + PR flow).
