### PR TITLE
SEAL: adopt Linux FHS as arifOS runtime contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,20 @@ arifosmcp.egg-info/
 VAULT999/
 eigent/
 
+# ── FHS Runtime Paths (never in git) ───────────────────────────────
+# These paths are runtime-only. Git tracks source, not state.
+/var/lib/arifOS/
+/var/lib/arifOS/**
+/run/arifOS/
+/run/arifOS/**
+/tmp/arifOS/
+/tmp/arifOS/**
+
+# ── Runtime Artifacts (never in git) ───────────────────────────────
+benchmark_report.json
+SEALED_EVENTS.jsonl
+*.jsonl
+
 # SQLite databases
 *.db
 

--- a/Dockerfile.fhs
+++ b/Dockerfile.fhs
@@ -1,0 +1,158 @@
+# ============================================================
+# arifOS — FHS-Aligned Container Build
+# Architect: Arif Fazil — Seri Kembangan, MY
+# Version: v2026.04.19-FHS
+# Constitutional Law: F1-F13 | DITEMPA BUKAN DIBERI
+#
+# Docker IS the FHS compiler.
+# Source tree → FHS paths → Governed runtime.
+# Git tracks source. Container enforces law.
+# ============================================================
+
+FROM python:3.12-slim AS base
+
+# ── System packages ─────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── FHS directory skeleton ──────────────────────────────────
+# These are constitutional declarations, not just mkdir.
+# Every path has exactly one semantic role — no overlap.
+RUN mkdir -p \
+    /etc/arifos/constitution \
+    /etc/arifos/manifests \
+    /usr/lib/arifos/kernel \
+    /usr/lib/arifos/tools \
+    /usr/lib/arifos/memory \
+    /usr/lib/arifos/intelligence \
+    /usr/lib/arifos/transport \
+    /usr/lib/arifos/vault \
+    /usr/lib/arifos/agents \
+    /usr/bin \
+    /var/lib/arifos/vault \
+    /var/log/arifos \
+    /run/arifos \
+    /tmp/arifos
+
+# ── Non-root runtime user ───────────────────────────────────
+RUN groupadd -r arifos && useradd -r -g arifos -s /sbin/nologin arifos
+
+# ── Volume declarations ─────────────────────────────────────
+# VAULT999 is runtime state. NEVER baked into image layer.
+# /var/lib/arifos/vault → bind mount to Supabase-synced host dir
+# /var/log/arifos      → bind mount to host log aggregator
+VOLUME ["/var/lib/arifos/vault", "/var/log/arifos"]
+
+
+# ============================================================
+# BUILD STAGE — install dependencies
+# ============================================================
+FROM base AS builder
+
+WORKDIR /build
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+
+# ============================================================
+# CONSTITUTION STAGE — bake F1-F13 manifests
+# Source: runtime/constitutional_map.py → /etc/arifos/
+# These are read-only at runtime. No process writes here.
+# ============================================================
+FROM base AS constitution
+
+COPY runtime/constitutional_map.py   /etc/arifos/constitution/constitutional_map.py
+COPY runtime/floors.py               /etc/arifos/constitution/floors.py
+
+# Tool and organ manifests (caller-facing contracts, not source)
+COPY runtime/manifests/              /etc/arifos/manifests/
+
+# Make constitution read-only — F12 (Resilience)
+RUN chmod -R 444 /etc/arifos/
+
+
+# ============================================================
+# FINAL STAGE — assemble governed runtime
+# ============================================================
+FROM base AS runtime
+
+# ── Install Python packages from builder ────────────────────
+COPY --from=builder /install /usr/local
+
+# ── /etc/arifos/ — Constitution (read-only) ─────────────────
+# F1-F13 floor definitions and tool manifests
+COPY --from=constitution /etc/arifos/ /etc/arifos/
+
+# ── /usr/lib/arifos/ — Installed source (read-only) ─────────
+# Organ decomposition: one directory = one organ = one concern
+
+# Kernel: F1-F13 engine, session management, routing
+COPY runtime/kernel/                 /usr/lib/arifos/kernel/
+
+# Tools: 13 public MCP tool implementations only
+# agentzero_tools.py → tools/agent.py (renamed, internal prefix stripped)
+# architect_tools.py → tools/forge.py (role → function)
+# benchmark_tools.py → /usr/lib/arifos/evals/ (not a public tool)
+COPY runtime/tools/                  /usr/lib/arifos/tools/
+
+# Memory: WELL organ, vector store, autonoetic, belief registry
+COPY runtime/memory/                 /usr/lib/arifos/memory/
+
+# Intelligence: GEOX + WEALTH reasoning organs
+COPY runtime/intelligence/           /usr/lib/arifos/intelligence/
+
+# Transport: A2A — single file from three (a2a_aligned + a2a_server + arifos_a2a → a2a.py)
+# 888 HOLD: merge the three A2A files before this COPY resolves
+COPY runtime/transport/a2a.py        /usr/lib/arifos/transport/a2a.py
+
+# Vault client (code only — data stays in /var/lib/arifos/vault/)
+COPY runtime/vault/                  /usr/lib/arifos/vault/
+
+# Agents: dispatch and registry (not agents_66, not agents_9)
+COPY runtime/agents/                 /usr/lib/arifos/agents/
+
+# Evals: benchmark and scoring (internal, not exposed as public tools)
+COPY runtime/evals/                  /usr/lib/arifos/evals/
+
+# Lock all source — no process modifies installed code at runtime (F12)
+RUN chmod -R 555 /usr/lib/arifos/
+
+# ── /usr/bin/ — Entry points ─────────────────────────────────
+COPY runtime/unified_server.py       /usr/bin/arifos-mcp
+COPY runtime/run.py                  /usr/bin/arifos-run
+RUN chmod 755 /usr/bin/arifos-mcp /usr/bin/arifos-run
+
+# ── /var/lib/arifos/ — Runtime mutable state ─────────────────
+# VAULT999 data lives here — mounted from host, never baked in
+# Directory created in base stage. Ownership to arifos user.
+RUN chown -R arifos:arifos /var/lib/arifos/ /var/log/arifos/ /run/arifos/ /tmp/arifos/
+
+# ── VAULT999 guard — F1 Amanah enforcement ───────────────────
+# If VAULT999/ accidentally exists in source, refuse to bake it
+# This makes the AMANAH violation a build failure, not a runtime surprise
+RUN test ! -d /usr/lib/arifos/vault/VAULT999 || \
+    (echo "AMANAH VIOLATION: VAULT999 data must not be in source layer" && exit 1)
+
+# ── Runtime environment ──────────────────────────────────────
+ENV ARIFOS_CONSTITUTION=/etc/arifos/constitution \
+    ARIFOS_MANIFESTS=/etc/arifos/manifests \
+    ARIFOS_LIB=/usr/lib/arifos \
+    ARIFOS_VAULT=/var/lib/arifos/vault \
+    ARIFOS_LOG=/var/log/arifos \
+    ARIFOS_RUN=/run/arifos \
+    PYTHONPATH=/usr/lib/arifos \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# ── Drop to non-root ─────────────────────────────────────────
+USER arifos
+
+# ── Health check ─────────────────────────────────────────────
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+EXPOSE 8000
+
+ENTRYPOINT ["/usr/bin/arifos-mcp"]

--- a/etc/arifOS/runtime-manifest.yaml
+++ b/etc/arifOS/runtime-manifest.yaml
@@ -1,0 +1,190 @@
+# /etc/arifOS/runtime-manifest.yaml
+# Canonical FHS contract for arifOS container runtime
+# SOURCE: git arifosmcp/ → BUILD → container /etc/arifOS/ (this file)
+# Agents: read this before reasoning about file placement. This is the law.
+
+version: "v2026.04.19"
+constitution: "F1-F13"
+anti_proliferation: true
+
+# ── BUILD BOUNDARY CONTRACT ──────────────────────────────────────────────────
+# git source tree → container runtime path
+# arifosmcp/ → /usr/lib/arifOS/ (pip install -e .)
+# arifosmcp/contracts/ → /etc/arifOS/contracts/ (COPY at build)
+# arifosmcp/specs/ → /etc/arifOS/specs/ (COPY at build)
+# arifosmcp/*.json → /etc/arifOS/ (COPY at build)
+# NEVER from git: → /var/lib/arifOS/ (runtime only, Supabase-backed)
+# NEVER from git: → /run/arifOS/ (ephemeral, process-generated)
+# NEVER from git: → /tmp/arifOS/ (ephemeral, process-generated)
+
+build_map:
+  source_root: "arifosmcp/"
+  install_target: "/usr/lib/arifOS/"
+  config_sources:
+    - pattern: "arifosmcp/contracts/**"
+      target: "/etc/arifOS/contracts/"
+    - pattern: "arifosmcp/specs/**"
+      target: "/etc/arifOS/specs/"
+    - pattern: "arifosmcp/*.json"
+      target: "/etc/arifOS/"
+  never_in_git:
+    - "/var/lib/arifOS/**"   # VAULT999, session state → Supabase
+    - "/run/arifOS/**"        # PID files, sockets → process-generated
+    - "/tmp/arifOS/**"        # ephemeral computation → discarded on container restart
+
+# ── ANTI-PROLIFERATION RULE ──────────────────────────────────────────────────
+# Every new Python file MUST go into an organ subpackage.
+# Flat .py files at arifosmcp/ root are FORBIDDEN except:
+#   - __init__.py (package anchor)
+#   - run.py        (Docker CMD entrypoint)
+#   - server.py     (MCP server binary → /usr/bin/arifos-mcp at build)
+# Any agent adding a flat .py at root is violating this contract.
+
+allowed_root_files:
+  - "__init__.py"
+  - "run.py"
+  - "server.py"
+  - "pyproject.toml"
+  - "requirements.txt"
+  - "uv.lock"
+  - "Dockerfile"
+  - "docker-compose.yml"
+  - ".env.example"
+  - ".gitignore"
+
+# ── 13 CANONICAL MCP TOOLS ────────────────────────────────────────────────────
+# These are the ONLY tools registered in /usr/bin/arifOS/ (MCP entry points).
+# Agents must not invent new top-level tools. New capabilities go inside organs.
+
+canonical_tools:
+  core:
+    - arifos_init
+    - arifos_sense
+    - arifos_mind
+    - arifos_kernel
+    - arifos_heart
+    - arifos_ops
+    - arifos_judge
+    - arifos_memory
+    - arifos_vault
+    - arifos_forge
+    - arifos_gateway
+  monitors:
+    - arifos_monitor_metabolism
+
+# ── /proc/arifOS/ INTERFACE ──────────────────────────────────────────────────
+# Read-only introspection. arifos_kernel tool is the /proc/ interface.
+# State it exposes (never writes):
+
+proc_interface:
+  - floor_states           # F1-F13 current health
+  - active_sessions        # session registry
+  - metabolic_vitals       # ΔS, Peace², Ω₀
+  - vault_chain_tip         # latest VAULT999 Merkle hash
+  - capability_map          # live organ availability
+
+# ── VAULT999 GOVERNANCE ──────────────────────────────────────────────────────
+# VAULT999 is persistent mutable state → /var/lib/arifOS/vault/
+# It is GITIGNORED. It is backed by Supabase (dual-write, MerkleV3).
+# Any VAULT999 directory in git is an error. Git-tracked vault = tampered ledger.
+
+vault:
+  runtime_path: "/var/lib/arifOS/vault/"
+  backend: "supabase"
+  merkle_version: "v3"
+  git_tracked: false   # MUST be false. If true, the build is broken.
+
+# ── FHS PATH MAP ───────────────────────────────────────────────────────────────
+
+filesystem:
+  /etc/arifOS/:
+    description: "Immutable config, constitutional law"
+    git_path: "etc/arifOS/"
+    contents: ["constitution/", "contracts/", "specs/", "*.json"]
+    rule: "No Python logic here. Config and contracts only."
+
+  /usr/lib/arifOS/:
+    description: "Installed package code (pip install -e .)"
+    git_path: "arifosmcp/"
+    rule: "Internal names do NOT become public tool names."
+
+  /usr/bin/arifOS/:
+    description: "13 canonical tool entry points (MCP surface)"
+    git_path: "NONE"   # Auto-generated, not in git
+    rule: "No tool name derived from source path."
+
+  /var/lib/arifOS/:
+    description: "Persistent mutable state (Supabase-backed)"
+    git_path: "NONE"
+    rule: "Never git-add. Supabase is authoritative store."
+
+  /var/log/arifOS/:
+    description: "Append-only audit logs"
+    git_path: "NONE"
+    rule: "Append-only. Never modify. Never delete."
+
+  /run/arifOS/:
+    description: "Ephemeral runtime (PID files, sockets)"
+    git_path: "NONE"
+
+  /tmp/arifOS/:
+    description: "Throw-away computation"
+    git_path: "NONE"
+    rule: "Assume wiped at any time."
+
+  /proc/arifOS/:
+    description: "Read-only runtime introspection"
+    git_path: "NONE"
+    rule: "arifos_kernel is the interface. Read-only."
+
+# ── ANTI-PROLIFERATION ENFORCEMENT ────────────────────────────────────────────
+
+naming_law:
+  principle: "Name by WHAT THE CALLER NEEDS. Never by WHERE CODE LIVES."
+
+  WRONG:
+    - "P_well_readiness_check    → leaks source path"
+    - "E_well_log               → leaks organ prefix"
+    - "T_petrophysics_compute   → leaks axis prefix"
+    - "V_npv_evaluate           → leaks valuation prefix"
+
+  RIGHT:
+    - "arifos_oracle_bio mode=readiness_check"
+    - "arifos_oracle_bio mode=log_update"
+    - "arifos_compute_physics mode=petrophysics"
+    - "arifos_compute_finance mode=npv"
+
+  ioctl_principle: "Same resource domain → one tool with mode= dispatch."
+  enforcement: "MCP registry rejects any tool with internal path component in name."
+  exception: "New top-level tool only if genuinely orthogonal. Requires Arif Fazil approval."
+
+# ── LIVE ENDPOINTS ─────────────────────────────────────────────────────────────
+
+endpoints:
+  canonical_domain: "mcp.arif-fazil.com"
+  legacy_alias: "arifosmcp.arif-fazil.com [DEPRECATED]"
+  mcp: "https://mcp.arif-fazil.com/mcp"
+  health: "https://mcp.arif-fazil.com/health"
+  source: "https://github.com/ariffazil/arifOS"
+
+# ── VERDICT SYSTEM ──────────────────────────────────────────────────────────────
+
+verdict:
+  SEAL:    "Passed all floors. Executed and logged."
+  HOLD:    "Irreversible or risky. Human confirmation required."
+  PARTIAL: "Passed with caveats. Limited execution."
+  VOID:    "Failed hard floor. Blocked."
+  rule: "No action proceeds to arifos_forge without SEAL from arifos_judge."
+
+# ── MANIFEST ACCURACY ───────────────────────────────────────────────────────────
+# If runtime and this manifest disagree, manifest is wrong.
+# Update this file, re-seal, rebuild.
+
+manifest_accuracy: "LIVE"
+last_verified: "2026-04-19T05:52:00Z"
+
+# ============================================================
+# Forged by Arif Fazil · Seri Kembangan, MY · April 2026
+# Architecture: 13 Tools · 13 Floors · FHS Runtime · Trinity ΔΩΨ
+# DITEMPA BUKAN DIBERI — 999 SEAL ALIVE
+# ============================================================


### PR DESCRIPTION
Closed — FHS content merged via PR #333. Dockerfile.fhs + .gitignore added to arifOS main.