### PR TITLE
release: command-center-mcp v0.1.1 KANON

### DIFF
--- a/arifosmcp/apps/command_center/app.py
+++ b/arifosmcp/apps/command_center/app.py
@@ -645,14 +645,10 @@ def command_center() -> PrefabApp:
 
 
 # Patch widget domain for ChatGPT MCP Apps sandbox compliance
-import asyncio
-
-_try_loop = asyncio.new_event_loop()
-for _tool in _try_loop.run_until_complete(command_center_app.list_tools()):
-    if _tool.name == "command_center":
-        _tool.meta.setdefault("ui", {})["domain"] = "https://arifosmcp.arif-fazil.com"
+for _key, _comp in command_center_app._local._components.items():
+    if _key.startswith("tool:") and getattr(_comp, "name", None) == "command_center":
+        _comp.meta.setdefault("ui", {})["domain"] = "https://arifosmcp.arif-fazil.com"
         break
-_try_loop.close()
 
 
 def _register(mcp: FastMCP) -> None:

--- a/arifosmcp/apps/command_center/app.py
+++ b/arifosmcp/apps/command_center/app.py
@@ -26,6 +26,7 @@ from arifosmcp.apps.command_center.models import (
 from arifosmcp.apps.command_center.state import get_state
 from fastmcp import FastMCP
 from fastmcp.apps import FastMCPApp
+from mcp.types import ToolAnnotations
 from prefab_ui.actions import SetState
 from prefab_ui.actions.mcp import CallTool
 from prefab_ui.app import PrefabApp
@@ -76,7 +77,13 @@ command_center_app = FastMCPApp("arifOS Command Center")
 
 @command_center_app.tool()
 def session_status() -> dict:
-    """Return current constitutional session status."""
+    """Use this when refreshing the constitutional session panel.
+
+    Returns the current actor ID, constitution hash, stage, lane, authority,
+    and sealed status. Read-only diagnostic.
+
+    Do not use for creating new sessions — use arif_session_init instead.
+    """
     state = get_state()
     state.session_count += 1
     return SessionStatus().model_dump()
@@ -84,7 +91,13 @@ def session_status() -> dict:
 
 @command_center_app.tool()
 def ops_vitals() -> dict:
-    """Return simulated thermodynamic health telemetry."""
+    """Use this when refreshing the thermodynamic health panel.
+
+    Returns simulated genius score (G), entropy delta (ΔS), human impact
+    load (Ω), and paradox tension (Ψ). Read-only diagnostic.
+
+    Do not use for actual system monitoring outside the Command Center.
+    """
     state = get_state()
     state.ops_reads += 1
     return OpsVitals().model_dump()
@@ -92,10 +105,17 @@ def ops_vitals() -> dict:
 
 @command_center_app.tool()
 def judge_action(candidate: str) -> dict:
-    """Adjudicate a candidate action against constitutional floors F1–F13.
+    """Use this when the user submits an action for constitutional review.
 
-    Returns SEAL, SABAR, HOLD, or VOID. Never permits real execution in v0.1.
+    Adjudicates the candidate against floors F1–F13 and returns a verdict:
+    SEAL (approved), SABAR (conditional), HOLD (paused), or VOID (rejected).
     Large or empty inputs fail closed to HOLD.
+
+    Parameters:
+        candidate: Plain-text description of the proposed action.
+            Example: "restart the production database" or "deploy v2.3".
+
+    Do not use for final execution — this only returns a verdict.
     """
     state = get_state()
     state.judge_calls += 1
@@ -108,9 +128,18 @@ def judge_action(candidate: str) -> dict:
 
 @command_center_app.tool()
 def forge_dry_run(manifest: str) -> dict:
-    """Simulate a forge execution without changing anything.
+    """Use this when the user wants to simulate a forge execution.
 
-    v0.1: dry_run only. No build, no deploy, no file write.
+    Accepts a manifest and returns a dry-run assessment including
+    reversibility classification and required verdict. No build, deploy,
+    or file write is performed in v0.1.
+
+    Parameters:
+        manifest: JSON manifest or plain-text description of the proposed
+            build/deploy operation.
+            Example: '{"mode": "deploy", "service": "arifosmcp"}'.
+
+    Do not use for real builds or deployments — this is simulation only.
     """
     state = get_state()
     state.forge_dry_runs += 1
@@ -135,9 +164,17 @@ def forge_dry_run(manifest: str) -> dict:
 
 @command_center_app.tool()
 def gateway_handshake(target_agent: str) -> dict:
-    """Simulate a constitutional cross-agent handshake.
+    """Use this when the user wants to simulate a cross-agent handshake.
 
-    No real network traffic. No credential exchange.
+    Accepts a target agent name and returns a simulated constitutional
+    handshake result including rogue-agent protection status. No real
+    network traffic or credential exchange occurs.
+
+    Parameters:
+        target_agent: Canonical agent name to handshake with.
+            Example: "geox-mcp", "wealth-mcp", "a-forge".
+
+    Do not use for actual A2A mesh routing — use arif_gateway_connect.
     """
     state = get_state()
     state.gateway_handshakes += 1
@@ -155,18 +192,28 @@ def gateway_handshake(target_agent: str) -> dict:
 
 @command_center_app.tool()
 def vault_list() -> dict:
-    """Return mock vault audit entries.
+    """Use this when refreshing the vault audit panel.
 
-    v0.1: synthetic data only. No ledger read from VAULT999.
+    Returns mock vault audit entries for demonstration. v0.1 uses synthetic
+    data only — no ledger read from VAULT999.
+
+    Do not use for retrieving real sealed events — use arif_vault_seal.
     """
     return VaultList(entries=MOCK_VAULT_ENTRIES).model_dump()
 
 
 @command_center_app.tool()
 def vault_dry_seal(payload: str) -> dict:
-    """Simulate a vault seal without permanent write.
+    """Use this when the user wants to preview a vault seal.
 
-    v0.1: not_written. No append to VAULT999.
+    Accepts a payload string and returns a hash preview and dry-seal status.
+    No permanent append to VAULT999 occurs in v0.1.
+
+    Parameters:
+        payload: The payload to hash and preview for sealing.
+            Example: '{"event": "deployment", "service": "arifosmcp"}'.
+
+    Do not use for permanent ledger writes — use arif_vault_seal.
     """
     state = get_state()
     state.vault_dry_seals += 1
@@ -181,14 +228,51 @@ def vault_dry_seal(payload: str) -> dict:
     ).model_dump()
 
 
+_READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+_DRY_RUN = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+
+_TOOL_ANNOTATIONS = {
+    "session_status": _READ_ONLY,
+    "ops_vitals": _READ_ONLY,
+    "judge_action": _READ_ONLY,
+    "forge_dry_run": _DRY_RUN,
+    "gateway_handshake": _DRY_RUN,
+    "vault_list": _READ_ONLY,
+    "vault_dry_seal": _DRY_RUN,
+}
+
+for _key, _comp in command_center_app._local._components.items():
+    if _key.startswith("tool:"):
+        _name = getattr(_comp, "name", None)
+        if _name in _TOOL_ANNOTATIONS:
+            _comp.annotations = _TOOL_ANNOTATIONS[_name]
+
+
 # ---------------------------------------------------------------------------
 # Visible UI entry point
 # ---------------------------------------------------------------------------
 
 
-@command_center_app.ui()
+@command_center_app.ui(
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    }
+)
 def command_center() -> PrefabApp:
-    """Open arifOS Command Center."""
+    """Use this when the user wants to open the arifOS Command Center.
+
+    This is the governed cockpit for constitutional AI operations across the
+    arifOS federation (arifOS, A-FORGE, GEOX, WEALTH). It provides tabs for
+    session status, thermodynamic vitals, constitutional judgment (888 Judge),
+    forge dry-run simulation (010 Forge), cross-agent gateway handshake
+    (666 Gateway), and vault audit (999 Vault).
+
+    Do not use for direct tool execution — use the specific canonical tool
+    (e.g., arif_judge_deliberate, arif_ops_measure) when the user asks for
+    a single action outside the cockpit context.
+    """
 
     # Header
     header = Column(

--- a/arifosmcp/apps/command_center/app.py
+++ b/arifosmcp/apps/command_center/app.py
@@ -644,6 +644,17 @@ def command_center() -> PrefabApp:
     )
 
 
+# Patch widget domain for ChatGPT MCP Apps sandbox compliance
+import asyncio
+
+_try_loop = asyncio.new_event_loop()
+for _tool in _try_loop.run_until_complete(command_center_app.list_tools()):
+    if _tool.name == "command_center":
+        _tool.meta.setdefault("ui", {})["domain"] = "https://arifosmcp.arif-fazil.com"
+        break
+_try_loop.close()
+
+
 def _register(mcp: FastMCP) -> None:
     """Mount arifOS Command Center onto the platform FastMCP server."""
     mcp.add_provider(command_center_app)

--- a/arifosmcp/server.py
+++ b/arifosmcp/server.py
@@ -277,55 +277,62 @@ try:
 
             tool_summaries = []
             try:
-                lp = getattr(mcp, "_local_provider", None)
-                if lp:
-                    raw_tools = {k: v for k, v in lp._components.items() if k.startswith("tool:")}
-                else:
-                    raw_tools = {}
-                for name, tool in raw_tools.items():
-                    tool_name = name.replace("tool:", "").rstrip("@")
-                    base = {
-                        "description": tool.description or "",
-                        "parameters": tool.parameters or {},
+                # Iterate over all providers (LocalProvider, AppProvider, etc.)
+                for provider in mcp.providers:
+                    # Access the internal _components map of each provider
+                    # Note: LocalProvider and AppProvider both have _components
+                    raw_tools = {
+                        k: v for k, v in provider._components.items() if k.startswith("tool:")
                     }
-                    manifest = TOOL_MANIFEST.get(tool_name, {})
-                    meta_dict = getattr(tool, "meta", None) or {}
-                    arifos_m = meta_dict.get("arifos_manifest", {}) or manifest
-                    entry = {
-                        "name": tool_name,
-                        "description": base["description"],
-                        "parameters": base["parameters"],
-                        "stage": arifos_m.get("stage_code", ""),
-                        "lane": arifos_m.get("lane", ""),
-                        "meta": {
-                            "arifos_manifest": arifos_m,
-                            "stage_code": meta_dict.get(
-                                "stage_code", arifos_m.get("stage_code", "")
-                            ),
-                            "stage_name": meta_dict.get(
-                                "stage_name", arifos_m.get("stage_name", "")
-                            ),
-                            "risk_tier": meta_dict.get(
-                                "risk_tier", arifos_m.get("risk", {}).get("tier", "low")
-                            ),
-                            "irreversible": meta_dict.get(
-                                "irreversible", arifos_m.get("risk", {}).get("irreversible", False)
-                            ),
-                            "requires_human_ack": meta_dict.get(
-                                "requires_human_ack",
-                                arifos_m.get("risk", {}).get("requires_human_ack", False),
-                            ),
-                            "use_when": arifos_m.get("use_when", []),
-                            "do_not_use_when": arifos_m.get("do_not_use_when", []),
-                            "next_recommended_tools": arifos_m.get("next_recommended_tools", []),
-                            "authority_boundary": arifos_m.get("authority_boundary", {}),
-                            "privacy_scope": arifos_m.get("privacy_scope", []),
-                            "canonical_order": meta_dict.get(
-                                "canonical_order", arifos_m.get("canonical_order", [])
-                            ),
-                        },
-                    }
-                    tool_summaries.append(entry)
+
+                    for name, tool in raw_tools.items():
+                        tool_name = name.replace("tool:", "").rstrip("@")
+                        base = {
+                            "description": tool.description or "",
+                            "parameters": tool.parameters or {},
+                        }
+                        manifest = TOOL_MANIFEST.get(tool_name, {})
+                        meta_dict = getattr(tool, "meta", None) or {}
+                        arifos_m = meta_dict.get("arifos_manifest", {}) or manifest
+                        entry = {
+                            "name": tool_name,
+                            "description": base["description"],
+                            "parameters": base["parameters"],
+                            "stage": arifos_m.get("stage_code", ""),
+                            "lane": arifos_m.get("lane", ""),
+                            "meta": {
+                                "arifos_manifest": arifos_m,
+                                "stage_code": meta_dict.get(
+                                    "stage_code", arifos_m.get("stage_code", "")
+                                ),
+                                "stage_name": meta_dict.get(
+                                    "stage_name", arifos_m.get("stage_name", "")
+                                ),
+                                "risk_tier": meta_dict.get(
+                                    "risk_tier", arifos_m.get("risk", {}).get("tier", "low")
+                                ),
+                                "irreversible": meta_dict.get(
+                                    "irreversible",
+                                    arifos_m.get("risk", {}).get("irreversible", False),
+                                ),
+                                "requires_human_ack": meta_dict.get(
+                                    "requires_human_ack",
+                                    arifos_m.get("risk", {}).get("requires_human_ack", False),
+                                ),
+                                "use_when": arifos_m.get("use_when", []),
+                                "do_not_use_when": arifos_m.get("do_not_use_when", []),
+                                "next_recommended_tools": arifos_m.get(
+                                    "next_recommended_tools", []
+                                ),
+                                "authority_boundary": arifos_m.get("authority_boundary", {}),
+                                "privacy_scope": arifos_m.get("privacy_scope", []),
+                                "canonical_order": meta_dict.get(
+                                    "canonical_order", arifos_m.get("canonical_order", [])
+                                ),
+                                "ui": meta_dict.get("ui", {}),
+                            },
+                        }
+                        tool_summaries.append(entry)
             except Exception as e:
                 logger.warning(f"Failed to build meta-enriched tools response: {e}")
                 tool_summaries = []
@@ -349,7 +356,6 @@ try:
         app.add_route("/webmcp/tools", tools_with_meta, methods=["GET"])
         app.add_route("/webmcp/metadata", horizon_metadata, methods=["GET"])
         app.add_route("/webmcp/.well-known/mcp", webmcp_discovery, methods=["GET"])
-
 
         # Overwrite Starlette routes list with our prioritized meta-enriched /tools
         app.add_route("/tools", tools_with_meta, methods=["GET"])

--- a/arifosmcp/server.py
+++ b/arifosmcp/server.py
@@ -279,10 +279,19 @@ try:
             try:
                 # Iterate over all providers (LocalProvider, AppProvider, etc.)
                 for provider in mcp.providers:
-                    # Access the internal _components map of each provider
-                    # Note: LocalProvider and AppProvider both have _components
+                    # Access the internal _components map
+                    # Some providers have it at the top level, others (like FastMCPApp) have it in _local
+                    raw_components = getattr(provider, "_components", None)
+                    if raw_components is None:
+                        local = getattr(provider, "_local", None)
+                        if local:
+                            raw_components = getattr(local, "_components", None)
+
+                    if not raw_components:
+                        continue
+
                     raw_tools = {
-                        k: v for k, v in provider._components.items() if k.startswith("tool:")
+                        k: v for k, v in raw_components.items() if k.startswith("tool:")
                     }
 
                     for name, tool in raw_tools.items():

--- a/arifosmcp/sites/app/index.html
+++ b/arifosmcp/sites/app/index.html
@@ -127,8 +127,22 @@
       text-decoration: none;
     }
   </style>
+  <link rel="stylesheet" href="/_shared/arifos.tokens.css">
+  <link rel="stylesheet" href="/_shared/arifos.nav.css">
+  <link rel="mcp-gateway" href="https://mcp.arif-fazil.com/.well-known/mcp">
 </head>
 <body>
+  <nav class="constellation-rail">
+    <a href="https://arif-fazil.com" class="nav-link" data-domain="arif">Ψ ARIF</a>
+    <a href="https://apex.arif-fazil.com" class="nav-link" data-domain="apex">Ω APEX</a>
+    <a href="https://mcp.arif-fazil.com" class="nav-link active-mcp" data-domain="mcp">Δ MCP</a>
+    <a href="https://aaa.arif-fazil.com" class="nav-link" data-domain="aaa">Δ AAA</a>
+    <a href="https://forge.arif-fazil.com" class="nav-link" data-domain="forge">Δ FORGE</a>
+    <a href="https://geox.arif-fazil.com" class="nav-link" data-domain="geox">Φ GEOX</a>
+    <a href="https://wealth.arif-fazil.com" class="nav-link" data-domain="wealth">Ξ WEALTH</a>
+    <a href="https://waw.arif-fazil.com" class="nav-link" data-domain="waw">Ξ WAW</a>
+    <a href="https://wiki.arif-fazil.com" class="nav-link" data-domain="wiki">Ω WIKI</a>
+  </nav>
   <div class="container">
     <div class="header">
       <h1>arifOS Command Center MCP</h1>
@@ -212,5 +226,7 @@
       <p style="margin-top:0.5rem; font-style: italic;">Ditempa bukan diberi.</p>
     </div>
   </div>
+  <script src="/_shared/arifos-nav.js"></script>
+  <script src="/_shared/vault999-client.js"></script>
 </body>
 </html>

--- a/arifosmcp/sites/app/index.html
+++ b/arifosmcp/sites/app/index.html
@@ -221,6 +221,7 @@
       <p style="margin-top:1rem">
         <a href="https://mcp.arif-fazil.com/">Home</a> ·
         <a href="https://mcp.arif-fazil.com/.well-known/mcp/server.json">Manifest</a> ·
+        <a href="https://mcp.arif-fazil.com/privacy.html">Privacy</a> ·
         <a href="https://github.com/ariffazil/arifOS">GitHub</a>
       </p>
       <p style="margin-top:0.5rem; font-style: italic;">Ditempa bukan diberi.</p>

--- a/arifosmcp/sites/apps/index.html
+++ b/arifosmcp/sites/apps/index.html
@@ -103,8 +103,22 @@
       text-decoration: none;
     }
   </style>
+  <link rel="stylesheet" href="/_shared/arifos.tokens.css">
+  <link rel="stylesheet" href="/_shared/arifos.nav.css">
+  <link rel="mcp-gateway" href="https://mcp.arif-fazil.com/.well-known/mcp">
 </head>
 <body>
+  <nav class="constellation-rail">
+    <a href="https://arif-fazil.com" class="nav-link" data-domain="arif">Ψ ARIF</a>
+    <a href="https://apex.arif-fazil.com" class="nav-link" data-domain="apex">Ω APEX</a>
+    <a href="https://mcp.arif-fazil.com" class="nav-link active-mcp" data-domain="mcp">Δ MCP</a>
+    <a href="https://aaa.arif-fazil.com" class="nav-link" data-domain="aaa">Δ AAA</a>
+    <a href="https://forge.arif-fazil.com" class="nav-link" data-domain="forge">Δ FORGE</a>
+    <a href="https://geox.arif-fazil.com" class="nav-link" data-domain="geox">Φ GEOX</a>
+    <a href="https://wealth.arif-fazil.com" class="nav-link" data-domain="wealth">Ξ WEALTH</a>
+    <a href="https://waw.arif-fazil.com" class="nav-link" data-domain="waw">Ξ WAW</a>
+    <a href="https://wiki.arif-fazil.com" class="nav-link" data-domain="wiki">Ω WIKI</a>
+  </nav>
   <div class="container">
     <div class="header">
       <h1>arifOS MCP Apps</h1>
@@ -148,5 +162,7 @@
       <p style="margin-top:0.5rem; font-style: italic;">Ditempa bukan diberi.</p>
     </div>
   </div>
+  <script src="/_shared/arifos-nav.js"></script>
+  <script src="/_shared/vault999-client.js"></script>
 </body>
 </html>

--- a/arifosmcp/sites/apps/index.html
+++ b/arifosmcp/sites/apps/index.html
@@ -157,7 +157,8 @@
       <p style="margin-top:1rem">
         <a href="https://mcp.arif-fazil.com/">Home</a> ·
         <a href="https://mcp.arif-fazil.com/app">Preview</a> ·
-        <a href="https://mcp.arif-fazil.com/.well-known/mcp/server.json">Manifest</a>
+        <a href="https://mcp.arif-fazil.com/.well-known/mcp/server.json">Manifest</a> ·
+        <a href="https://mcp.arif-fazil.com/privacy.html">Privacy</a>
       </p>
       <p style="margin-top:0.5rem; font-style: italic;">Ditempa bukan diberi.</p>
     </div>

--- a/deploy/machine-law/Caddyfile
+++ b/deploy/machine-law/Caddyfile
@@ -94,10 +94,16 @@ mcp.arif-fazil.com {
     handle / {
         file_server
     }
+    handle /privacy* {
+        file_server
+    }
     handle /webmcp* {
         file_server
     }
     handle /app* {
+        file_server
+    }
+    handle /apps* {
         file_server
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,8 @@ services:
     depends_on:
       vault999:
         condition: service_healthy
+    volumes:
+      - /root/geox/geox_mcp_server.py:/app/geox_mcp_server.py:ro
 
   wealth-organ:
     build: /root/arifOS/skills/wealth

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arifos"
-version = "2026.04.26.post0"
+version = "0.1.1"
 description = "arifOS v2026.04.26-KANON — Constitutional AI Governance System. 13 canonical MCP capability tools, 13 constitutional floors (F1-F13), streamable-http MCP transport. CANONICAL SOURCE OF TRUTH: arifOS repository."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## v0.1.1 KANON — Command Center MCP

### What's included

| Commit | Description |
|---|---|
|  | chore(release): align app docs and Caddyfile routes |
|  | fix(kernel): remove ghost modes stage/lane/list from arif_kernel_route manifest |
|  | feat(federation): inject Constellation Rail + mcp-gateway into /app and /apps |
|  | fix(chatgpt): avoid event loop conflict when patching widget_domain at import time |
|  | fix(chatgpt): add widget_domain to Command Center for MCP Apps sandbox compliance |
|  | Add arifOS Command Center MCP Apps v0.1.1 |

### Summary
- **13 constitutional tools** — canonical surface, no ghosts
- **1 MCP app** —  with  for sandbox compliance
- **Ghost mode fix** —  manifest now matches runtime (route, status only)
- **Federation Alignment** — Constellation Rail + mcp-gateway injected into /app and /apps
- **Caddyfile** — /privacy*, /webmcp*, /app*, /apps* routes fixed

### Container
`ghcr.io/ariffazil/arifos:v0.1.1` — healthy, 13 tools, 1 app

**888_HOLD**: Evaluate before merge. Ghost mode contract is now clean.