### PR TITLE
merge: unify feat/llm-wire-cognition-organs + fix/threat-engine-scan into main

### DIFF
--- a/arifosmcp/core/threat_engine.py
+++ b/arifosmcp/core/threat_engine.py
@@ -18,13 +18,6 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 
-class ThreatTier(Enum):
-    SAFE = 0
-    CAUTION = 1
-    HOLD = 2
-    VOID = 3
-
-
 class ThreatCategory(Enum):
     """Canonical threat taxonomy — used by all tools. No exceptions."""
 


### PR DESCRIPTION
## Summary
- Merges feat/llm-wire-cognition-organs (cognition organ wiring) into main
- Merges fix/threat-engine-scan (ThreatEngine.scan() + ThreatTier + ScanResult) into main
- Cleans up duplicate ThreatTier enum definition from origin/main

## What changed
- feat/llm-wire-cognition-organs: already identical to main (no-op merge)
- fix/threat-engine-scan: ThreatEngine.scan() + ThreatTier enum + ScanResult class added at end of threat_engine.py — resolves AttributeError when tools call .scan()
- Deduplication commit: removed the old duplicate ThreatTier(SAFE/CAUTION/HOLD/VOID) that existed in origin/main before the canonical ThreatTier(VOID/SEAL/SABAR/HOLD) was added by fix/threat-engine-scan

## Verification
```bash
python -c "from arifosmcp.core.threat_engine import ThreatEngine, ThreatTier, ScanResult; r = ThreatEngine.scan('print(hello)'); print(r)"
```
