### PR TITLE
docs(arifOS): correct GEOX port + tool count in FEDERATION_STATUS.md

### DIFF
--- a/FEDERATION_STATUS.md
+++ b/FEDERATION_STATUS.md
@@ -12,7 +12,7 @@
 |-------|------|-------------|------|--------|-------|
 | **Constitutional Kernel** | `ariffazil/arifOS` | `/root/arifOS` | `8088` | ✅ OPERATIONAL | streamable-http, 13 tools, F1-F13 active |
 | **AAA Control Plane** | `ariffazil/AAA` | `/root/AAA` | `3001` (A2A) | ✅ OPERATIONAL | Cockpit + A2A gateway |
-| **GEOX Earth Intel** | `ariffazil/geox` | `/root/geox` | `18081` | ✅ OPERATIONAL | 28 canonical tools |
+| **GEOX Earth Intel** | `ariffazil/geox` | `/root/geox` | `8081` | ✅ OPERATIONAL | 20 canonical tools |
 | **WEALTH Capital** | `ariffazil/wealth` | `/root/WEALTH` | `18082` | ✅ OPERATIONAL | 17 public MCP tools |
 | **WELL Vitality** | `ariffazil/well` | `/root/WELL` | `18083` | ✅ OPERATIONAL | 45 live MCP tools (post PHOENIX-73F), 51 decorators, `streamable-http` at `https://well.arif-fazil.com/mcp` |
 | **A-FORGE Execution** | `ariffazil/A-FORGE` | `/root/A-FORGE` | `7071` (bridge) | ✅ OPERATIONAL | TypeScript engine |


### PR DESCRIPTION
1-line correction on the GEOX row of the federation status table.

**Before:** `18081` (wrong — that is arifosd) + `28 canonical tools` (stale — live is 20)
**After:**  `8081` (correct — organ-standard, live on geox-mcp.service) + `20 canonical tools`

This aligns the arifOS-side federation view with the actual live state in the GEOX repo (geox commits 094cdd2a, 702b27f3, 50daa136 corrected README/AGENTS/INVARIANTS to 20 tools / port 8081 earlier this session).

Diagnostic only. No code change, no manifest change. The Caddyfile misroute (`/api/organs/geox/health` → `:18081` instead of `:8081`) is **888_HOLD** territory and is documented in `/root/geox/INVARIANTS.md` lines 57-63. This PR does NOT touch the Caddyfile — flagged for separate sovereign call.