### PR TITLE
test: lock runtime public surface invariants

### DIFF
--- a/tests/test_public_surface_runtime_invariants.py
+++ b/tests/test_public_surface_runtime_invariants.py
@@ -1,0 +1,97 @@
+"""
+Runtime public surface invariants for the arifOS MCP facade.
+
+These tests bind the resolver used by runtime code, not only the static
+canonical constants. The goal is to catch connector/tool-list drift before
+agents expose internal machinery to public clients.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from arifosmcp.runtime.public_surface import (
+    CANONICAL_7,
+    public_tool_names_for_mode,
+)
+
+EXPECTED_PUBLIC_TOOLS = frozenset(
+    {
+        "arif_init",
+        "arif_observe",
+        "arif_think",
+        "arif_route",
+        "arif_judge",
+        "arif_act",
+        "arif_seal",
+    }
+)
+
+FORBIDDEN_DEFAULT_PUBLIC_TOOLS = frozenset(
+    {
+        "arif_bridge_connect",
+        "arif_gateway_connect",
+        "arif_forge",
+        "arif_forge_execute",
+        "arif_memory",
+        "arif_memory_recall",
+        "arif_vault_seal",
+        "hermes_vault_query",
+        "arif_canary",
+        "arif_conformance_report",
+    }
+)
+
+
+@pytest.mark.parametrize("mode", [None, "canonical13", "public", "chatgpt", "agnostic_public"])
+def test_runtime_public_surface_resolves_to_canonical7(mode: str | None):
+    """Default/public runtime modes must resolve to exactly the 7-tool facade."""
+    resolved = set(public_tool_names_for_mode(mode))
+
+    assert resolved == set(CANONICAL_7) == set(EXPECTED_PUBLIC_TOOLS)
+    assert len(resolved) == 7
+
+
+def test_default_runtime_surface_excludes_internal_and_diagnostic_tools():
+    """Default tools/list must not leak aliases, diagnostics, bridge, forge, memory, or vault."""
+    resolved = set(public_tool_names_for_mode(None))
+    leaked = resolved & FORBIDDEN_DEFAULT_PUBLIC_TOOLS
+
+    assert not leaked, f"Forbidden tools leaked into default public surface: {sorted(leaked)}"
+
+
+def test_canonical13_surface_excludes_internal_and_diagnostic_tools():
+    """Explicit canonical13 mode must remain public-safe."""
+    resolved = set(public_tool_names_for_mode("canonical13"))
+    leaked = resolved & FORBIDDEN_DEFAULT_PUBLIC_TOOLS
+
+    assert not leaked, f"Forbidden tools leaked into canonical13 surface: {sorted(leaked)}"
+
+
+def test_expanded45_mode_is_not_default_public_surface(monkeypatch: pytest.MonkeyPatch):
+    """Expanded/operator mode must never activate from the default resolver by accident."""
+    monkeypatch.delenv("ARIFOS_PUBLIC_SURFACE_MODE", raising=False)
+    monkeypatch.delenv("ARIFOS_PUBLIC_TOOL_PROFILE", raising=False)
+    monkeypatch.delenv("ARIFOS_MCP_EXPOSE_DEV_TOOLS", raising=False)
+
+    resolved = set(public_tool_names_for_mode(None))
+
+    assert resolved == set(EXPECTED_PUBLIC_TOOLS)
+    assert "arif_conformance_report" not in resolved
+    assert "arif_canary" not in resolved
+
+
+def test_expanded45_requires_explicit_dev_gate(monkeypatch: pytest.MonkeyPatch):
+    """
+    Expanded45 is an operator/dev surface and must not be reachable merely by
+    passing mode='expanded45' unless the explicit dev-tools gate is enabled.
+
+    This test intentionally encodes the safety invariant needed after the
+    connector exposed an expanded surface to ChatGPT.
+    """
+    monkeypatch.delenv("ARIFOS_MCP_EXPOSE_DEV_TOOLS", raising=False)
+
+    resolved = set(public_tool_names_for_mode("expanded45"))
+
+    assert resolved == set(EXPECTED_PUBLIC_TOOLS)
+    assert not (resolved & FORBIDDEN_DEFAULT_PUBLIC_TOOLS)


### PR DESCRIPTION
## Verdict
DRAFT_ONLY / TEST_ONLY.

This PR adds runtime invariant tests for the MCP public surface. It does not change production code.

## Why
The repo already has static canonical 7-tool tests, but the ChatGPT connector previously exposed an expanded/operator-like surface. This PR locks the runtime resolver path so drift is caught before public tools/list leaks internal machinery.

## Added
`tests/test_public_surface_runtime_invariants.py`

Tests added:
- default/public resolver modes return exactly `CANONICAL_7`
- forbidden internal/diagnostic tools do not appear in default or canonical13 mode
- default resolver cannot accidentally activate expanded/operator surface
- `expanded45` requires explicit dev gate safety invariant

## Expected follow-up
The final test may fail on current runtime if `public_tool_names_for_mode("expanded45")` exposes expanded tools without checking `ARIFOS_MCP_EXPOSE_DEV_TOOLS`. That failure is intentional: it defines the safety invariant for the next fix PR.

## Agent receipt
```yaml
agent_receipt:
  agent: ChatGPT_TEST_AGENT
  branch: test/public-surface-runtime-invariants
  files_changed:
    - tests/test_public_surface_runtime_invariants.py
  invariant_target: runtime public MCP surface resolves to canonical 7 tools unless explicitly gated
  tests_added:
    - test_runtime_public_surface_resolves_to_canonical7
    - test_default_runtime_surface_excludes_internal_and_diagnostic_tools
    - test_canonical13_surface_excludes_internal_and_diagnostic_tools
    - test_expanded45_mode_is_not_default_public_surface
    - test_expanded45_requires_explicit_dev_gate
  tests_run:
    command: not_run_by_connector
    result: hold
  risks:
    - expanded45 gate test may currently fail until runtime gate is hardened
  did_not_touch:
    - forge
    - seal
    - memory
    - vault
    - deployment
  verdict: READY_FOR_REVIEW
```

Closes part of #526.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added runtime checks to ensure the app’s public tool surface stays consistent across default and common modes.
  * Verified that default and standard modes expose only the expected core set of tools and exclude internal/diagnostic tools.
  * Confirmed the expanded tool set cannot be reached accidentally and only appears when explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->