### PR TITLE
feat(kernel): add AGI-substrate readiness gate

### DIFF
--- a/arifosmcp/kernel/substrate_readiness.py
+++ b/arifosmcp/kernel/substrate_readiness.py
@@ -1,0 +1,244 @@
+"""
+arifosmcp/kernel/substrate_readiness.py — AGI-substrate readiness gate
+
+This module does not claim arifOS is AGI. It defines the minimum machine-
+checkable substrate gates a governed agentic kernel must satisfy before AGI-like
+execution language is admissible.
+
+A kernel earns readiness by passing invariants, not by asserting intelligence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Iterable
+
+from arifosmcp.kernel.capability_registry import _build_default_graph
+from arifosmcp.kernel.models import CapabilityGraph, MutationClass
+from arifosmcp.runtime.public_surface import CANONICAL_7, public_tool_names_for_mode
+
+
+class ReadinessVerdict(StrEnum):
+    """Substrate verdict. FAIL is intentional until every gate is proven."""
+
+    READY = "READY"
+    HOLD = "HOLD"
+
+
+@dataclass(frozen=True)
+class ReadinessCheck:
+    """One machine-checkable readiness invariant."""
+
+    check_id: str
+    passed: bool
+    summary: str
+    remediation: str = ""
+    evidence: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ReadinessReport:
+    """Aggregate substrate-readiness report."""
+
+    verdict: ReadinessVerdict
+    score: int
+    passed: int
+    total: int
+    checks: tuple[ReadinessCheck, ...]
+
+    @property
+    def failed_checks(self) -> tuple[ReadinessCheck, ...]:
+        return tuple(check for check in self.checks if not check.passed)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "verdict": self.verdict.value,
+            "score": self.score,
+            "passed": self.passed,
+            "total": self.total,
+            "checks": [
+                {
+                    "check_id": check.check_id,
+                    "passed": check.passed,
+                    "summary": check.summary,
+                    "remediation": check.remediation,
+                    "evidence": check.evidence,
+                }
+                for check in self.checks
+            ],
+        }
+
+
+FORBIDDEN_PUBLIC_TOOLS: frozenset[str] = frozenset(
+    {
+        "arif_bridge_connect",
+        "arif_gateway_connect",
+        "arif_forge",
+        "arif_forge_execute",
+        "arif_memory",
+        "arif_memory_recall",
+        "arif_vault_seal",
+        "hermes_vault_query",
+        "arif_canary",
+        "arif_conformance_report",
+    }
+)
+
+REQUIRED_CORE_TOOLS: frozenset[str] = frozenset(CANONICAL_7)
+IRREVERSIBLE_PUBLIC_COMMIT_GATES: frozenset[str] = frozenset({"arif_act", "arif_seal"})
+
+
+def _tool_names(graph: CapabilityGraph) -> set[str]:
+    return {cap.tool_name for cap in graph.capabilities}
+
+
+def _capabilities_for_tools(graph: CapabilityGraph, tool_names: Iterable[str]):
+    wanted = set(tool_names)
+    return [cap for cap in graph.capabilities if cap.tool_name in wanted]
+
+
+def _public_surface_check() -> ReadinessCheck:
+    public_tools = set(public_tool_names_for_mode(None))
+    expected = set(CANONICAL_7)
+    leaked = sorted(public_tools & FORBIDDEN_PUBLIC_TOOLS)
+    missing = sorted(expected - public_tools)
+    extra = sorted(public_tools - expected)
+    passed = not leaked and not missing and not extra and len(public_tools) == 7
+
+    return ReadinessCheck(
+        check_id="SURFACE_7_PUBLIC_VERBS",
+        passed=passed,
+        summary="Default public MCP surface resolves to exactly the seven canonical verbs.",
+        remediation="Force default public mode to CANONICAL_7 and keep bridge/forge/memory/vault/canary internal.",
+        evidence={
+            "public_tools": sorted(public_tools),
+            "missing": missing,
+            "extra": extra,
+            "leaked_forbidden": leaked,
+        },
+    )
+
+
+def _capability_graph_core_check(graph: CapabilityGraph) -> ReadinessCheck:
+    names = _tool_names(graph)
+    missing = sorted(REQUIRED_CORE_TOOLS - names)
+    passed = not missing and bool(graph.version.graph_hash)
+
+    return ReadinessCheck(
+        check_id="CAPABILITY_GRAPH_COVERS_CORE_SEVEN",
+        passed=passed,
+        summary="Capability graph contains every canonical public tool and carries a graph hash.",
+        remediation="Register every CANONICAL_7 tool as a CapabilityNode and keep graph hashing active.",
+        evidence={
+            "missing_core_tools": missing,
+            "graph_hash_present": bool(graph.version.graph_hash),
+            "capability_count": graph.version.capability_count,
+        },
+    )
+
+
+def _commit_gate_check(graph: CapabilityGraph) -> ReadinessCheck:
+    core_caps = _capabilities_for_tools(graph, REQUIRED_CORE_TOOLS)
+    irreversible = sorted(cap.tool_name for cap in core_caps if cap.irreversible)
+    passed = set(irreversible).issubset(IRREVERSIBLE_PUBLIC_COMMIT_GATES)
+
+    return ReadinessCheck(
+        check_id="ONLY_ACT_AND_SEAL_COMMIT_IRREVERSIBLY",
+        passed=passed,
+        summary="Only arif_act and arif_seal may be irreversible public commitment gates.",
+        remediation="Move irreversible effect out of observe/think/route/judge/init and into act/seal gates.",
+        evidence={
+            "irreversible_public_core_tools": irreversible,
+            "allowed_irreversible_commit_gates": sorted(IRREVERSIBLE_PUBLIC_COMMIT_GATES),
+        },
+    )
+
+
+def _mutation_discipline_check(graph: CapabilityGraph) -> ReadinessCheck:
+    mutating = [
+        cap
+        for cap in graph.capabilities
+        if cap.mutation_class not in (MutationClass.NONE,) or cap.irreversible
+    ]
+    unsafe = sorted(
+        cap.tool_name
+        for cap in mutating
+        if not cap.audit_required or cap.allow_python_fallback
+    )
+    passed = not unsafe
+
+    return ReadinessCheck(
+        check_id="MUTATIONS_ARE_AUDITED_NO_UNIVERSAL_FALLBACK",
+        passed=passed,
+        summary="Mutating capabilities require audit and cannot fall back to unconstrained Python execution.",
+        remediation="Set audit_required=True and allow_python_fallback=False for every mutating capability.",
+        evidence={
+            "mutating_capability_count": len(mutating),
+            "unsafe_mutating_tools": unsafe,
+        },
+    )
+
+
+def _irreversible_externality_check(graph: CapabilityGraph) -> ReadinessCheck:
+    irreversible = [cap for cap in graph.capabilities if cap.irreversible]
+    unsafe = sorted(
+        cap.tool_name
+        for cap in irreversible
+        if not (cap.requires_external_witness or cap.requires_external_anchor or cap.requires_888_hold)
+    )
+    passed = not unsafe
+
+    return ReadinessCheck(
+        check_id="IRREVERSIBLE_ACTIONS_REQUIRE_EXTERNALITY_OR_HOLD",
+        passed=passed,
+        summary="Irreversible capabilities require external witness, external evidence anchor, or 888_HOLD.",
+        remediation="Add requires_external_witness, requires_external_anchor, or requires_888_hold to irreversible capabilities.",
+        evidence={
+            "irreversible_capability_count": len(irreversible),
+            "unsafe_irreversible_tools": unsafe,
+        },
+    )
+
+
+def _anti_hantu_fallback_check(graph: CapabilityGraph) -> ReadinessCheck:
+    fallback_allowed = sorted(cap.tool_name for cap in graph.capabilities if cap.allow_python_fallback)
+    passed = not fallback_allowed
+
+    return ReadinessCheck(
+        check_id="NO_UNIVERSAL_PYTHON_ESCAPE_HATCH",
+        passed=passed,
+        summary="No capability may silently degrade into generic Python execution.",
+        remediation="Keep allow_python_fallback=False unless a capability is sandboxed, audited, and explicitly ratified.",
+        evidence={"fallback_allowed_tools": fallback_allowed},
+    )
+
+
+def assess_substrate_readiness(graph: CapabilityGraph | None = None) -> ReadinessReport:
+    """
+    Assess whether arifOS satisfies the minimum AGI-substrate invariants.
+
+    READY does not mean AGI. READY means the kernel surface, capability graph,
+    mutation discipline, and irreversible-action gates are coherent enough to
+    allow agentic execution work to proceed without hantu authority claims.
+    """
+    graph = graph or _build_default_graph()
+    checks = (
+        _public_surface_check(),
+        _capability_graph_core_check(graph),
+        _commit_gate_check(graph),
+        _mutation_discipline_check(graph),
+        _irreversible_externality_check(graph),
+        _anti_hantu_fallback_check(graph),
+    )
+    passed = sum(1 for check in checks if check.passed)
+    total = len(checks)
+    score = round((passed / total) * 100) if total else 0
+    verdict = ReadinessVerdict.READY if passed == total else ReadinessVerdict.HOLD
+    return ReadinessReport(
+        verdict=verdict,
+        score=score,
+        passed=passed,
+        total=total,
+        checks=checks,
+    )

--- a/docs/AGI_SUBSTRATE_READINESS_GATE.md
+++ b/docs/AGI_SUBSTRATE_READINESS_GATE.md
@@ -1,0 +1,78 @@
+# AGI Substrate Readiness Gate
+
+## Verdict
+
+This gate does **not** claim arifOS is AGI.
+
+It defines the minimum machine-checkable substrate conditions a governed agentic kernel must satisfy before AGI-like execution language is admissible.
+
+Plain rule:
+
+```text
+No substrate proof, no AGI claim.
+```
+
+## Why this exists
+
+arifOS already has the shape of a governed intelligence kernel:
+
+```text
+init → observe → think → route → judge → act → seal
+```
+
+But architecture alone is not enough. A real kernel must prove that:
+
+1. Public agents see only the canonical seven verbs.
+2. Internal sovereign machinery does not leak to public `tools/list`.
+3. Every public verb exists in the capability graph.
+4. Irreversible effects are restricted to `arif_act` and `arif_seal`.
+5. Mutating capabilities are audited.
+6. Irreversible capabilities require external witness, external evidence anchor, or `888_HOLD`.
+7. No tool silently falls back to generic Python execution.
+
+## New module
+
+```text
+arifosmcp/kernel/substrate_readiness.py
+```
+
+Primary entrypoint:
+
+```python
+from arifosmcp.kernel.substrate_readiness import assess_substrate_readiness
+
+report = assess_substrate_readiness()
+print(report.to_dict())
+```
+
+## Verdict vocabulary
+
+```text
+READY = all substrate gates pass
+HOLD  = at least one gate fails
+```
+
+`READY` does not mean AGI. It means the kernel is coherent enough to continue agentic execution work without hantu authority claims.
+
+## Gate list
+
+| Gate | Meaning |
+|---|---|
+| `SURFACE_7_PUBLIC_VERBS` | Default MCP public surface is exactly the canonical seven tools. |
+| `CAPABILITY_GRAPH_COVERS_CORE_SEVEN` | Capability graph contains the seven public tools and has a graph hash. |
+| `ONLY_ACT_AND_SEAL_COMMIT_IRREVERSIBLY` | Only `arif_act` and `arif_seal` may commit irreversible public effects. |
+| `MUTATIONS_ARE_AUDITED_NO_UNIVERSAL_FALLBACK` | Mutating tools require audit and cannot fall back to unconstrained Python. |
+| `IRREVERSIBLE_ACTIONS_REQUIRE_EXTERNALITY_OR_HOLD` | Irreversible tools need externality or `888_HOLD`. |
+| `NO_UNIVERSAL_PYTHON_ESCAPE_HATCH` | No capability silently degrades to generic Python execution. |
+
+## Operator meaning
+
+If the report returns `HOLD`, agents should not expand tools, add features, or claim AGI progress. They should fix the failed gates first.
+
+If the report returns `READY`, agents may continue with controlled kernel work, still under F13 review for irreversible action.
+
+## Non-negotiable
+
+```text
+arifOS becomes more real by reducing unearned authority, not by adding more tool names.
+```

--- a/tests/kernel/test_substrate_readiness.py
+++ b/tests/kernel/test_substrate_readiness.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from arifosmcp.kernel.models import (
+    AuthorityTier,
+    BlastRadius,
+    CapabilityGraph,
+    CapabilityNode,
+    GraphVersion,
+    MutationClass,
+    ResourceClass,
+    TrustState,
+)
+from arifosmcp.kernel.substrate_readiness import (
+    FORBIDDEN_PUBLIC_TOOLS,
+    REQUIRED_CORE_TOOLS,
+    ReadinessVerdict,
+    assess_substrate_readiness,
+)
+
+
+def _ready_graph() -> CapabilityGraph:
+    capabilities: list[CapabilityNode] = []
+    for tool_name in sorted(REQUIRED_CORE_TOOLS):
+        capabilities.append(
+            CapabilityNode(
+                capability_id=f"kernel.{tool_name}",
+                tool_name=tool_name,
+                server_id="local",
+                description=f"Test capability for {tool_name}",
+                authority_required=AuthorityTier.LOW,
+                mutation_class=MutationClass.NONE,
+                irreversible=False,
+                blast_radius=BlastRadius.LOCAL,
+                resource_class=ResourceClass.MEMORY,
+                organ_id="arifOS",
+                trust_state=TrustState.TRUSTED_READ,
+                allow_python_fallback=False,
+            )
+        )
+
+    for gate in ("arif_act", "arif_seal"):
+        for cap in capabilities:
+            if cap.tool_name == gate:
+                cap.mutation_class = MutationClass.IRREVERSIBLE
+                cap.irreversible = True
+                cap.audit_required = True
+                cap.requires_888_hold = True
+                cap.requires_external_anchor = True
+
+    return CapabilityGraph(
+        version=GraphVersion(version_id="test-ready"),
+        capabilities=capabilities,
+    )
+
+
+def test_substrate_readiness_returns_report_shape():
+    report = assess_substrate_readiness(_ready_graph())
+
+    assert report.total == 6
+    assert report.passed == 6
+    assert report.score == 100
+    assert report.verdict == ReadinessVerdict.READY
+    assert report.failed_checks == ()
+    assert report.to_dict()["verdict"] == "READY"
+
+
+def test_substrate_readiness_detects_missing_core_tool():
+    graph = _ready_graph()
+    graph.capabilities = [cap for cap in graph.capabilities if cap.tool_name != "arif_act"]
+    graph.model_post_init(None)
+
+    report = assess_substrate_readiness(graph)
+
+    assert report.verdict == ReadinessVerdict.HOLD
+    failed = {check.check_id: check for check in report.failed_checks}
+    assert "CAPABILITY_GRAPH_COVERS_CORE_SEVEN" in failed
+    assert failed["CAPABILITY_GRAPH_COVERS_CORE_SEVEN"].evidence["missing_core_tools"] == ["arif_act"]
+
+
+def test_substrate_readiness_blocks_unsafe_mutation():
+    graph = _ready_graph()
+    graph.add(
+        CapabilityNode(
+            capability_id="unsafe.write",
+            tool_name="unsafe_write",
+            server_id="local",
+            description="Unsafe write without audit",
+            authority_required=AuthorityTier.MEDIUM,
+            mutation_class=MutationClass.ORG_STATE,
+            irreversible=False,
+            blast_radius=BlastRadius.PROCESS,
+            resource_class=ResourceClass.FILE,
+            audit_required=False,
+            allow_python_fallback=True,
+            trust_state=TrustState.PROBATION,
+        )
+    )
+
+    report = assess_substrate_readiness(graph)
+
+    failed = {check.check_id: check for check in report.failed_checks}
+    assert "MUTATIONS_ARE_AUDITED_NO_UNIVERSAL_FALLBACK" in failed
+    assert "unsafe_write" in failed["MUTATIONS_ARE_AUDITED_NO_UNIVERSAL_FALLBACK"].evidence[
+        "unsafe_mutating_tools"
+    ]
+    assert "NO_UNIVERSAL_PYTHON_ESCAPE_HATCH" in failed
+
+
+def test_substrate_readiness_blocks_unwitnessed_irreversible_action():
+    graph = _ready_graph()
+    graph.add(
+        CapabilityNode(
+            capability_id="unsafe.delete",
+            tool_name="unsafe_delete",
+            server_id="local",
+            description="Irreversible delete without witness or hold",
+            authority_required=AuthorityTier.HIGH,
+            mutation_class=MutationClass.IRREVERSIBLE,
+            irreversible=True,
+            blast_radius=BlastRadius.FEDERATION,
+            resource_class=ResourceClass.FILE,
+            audit_required=True,
+            allow_python_fallback=False,
+            trust_state=TrustState.PROBATION,
+        )
+    )
+
+    report = assess_substrate_readiness(graph)
+
+    failed = {check.check_id: check for check in report.failed_checks}
+    assert "IRREVERSIBLE_ACTIONS_REQUIRE_EXTERNALITY_OR_HOLD" in failed
+    assert "unsafe_delete" in failed[
+        "IRREVERSIBLE_ACTIONS_REQUIRE_EXTERNALITY_OR_HOLD"
+    ].evidence["unsafe_irreversible_tools"]
+
+
+def test_forbidden_public_tool_set_names_sovereign_machinery():
+    assert {
+        "arif_bridge_connect",
+        "arif_gateway_connect",
+        "arif_forge_execute",
+        "arif_vault_seal",
+        "arif_memory_recall",
+        "hermes_vault_query",
+        "arif_canary",
+        "arif_conformance_report",
+    }.issubset(FORBIDDEN_PUBLIC_TOOLS)


### PR DESCRIPTION
## Verdict
DRAFT_ONLY / WOW_PR / NO_AGI_CLAIM.

This PR does not claim arifOS is AGI. It adds a machine-checkable substrate readiness gate so arifOS cannot use AGI-kernel language unless core invariants are proven.

## Deep scan basis
The repo already defines:
- a 7-tool public metabolic loop in `constitutional_map.py`
- a capability graph with authority, mutation, blast radius, trust state, evidence, and witness fields
- public surface code that is supposed to hide internal/diagnostic machinery

This PR turns that architecture into an executable readiness report.

## Added

### 1. `arifosmcp/kernel/substrate_readiness.py`
Adds:
- `ReadinessVerdict`
- `ReadinessCheck`
- `ReadinessReport`
- `assess_substrate_readiness()`

The report checks:
- default public MCP surface is exactly canonical 7
- forbidden sovereign machinery does not appear publicly
- capability graph covers all core seven tools
- only `arif_act` and `arif_seal` may be irreversible public commitment gates
- mutating tools require audit and no universal Python fallback
- irreversible tools require external witness, external anchor, or `888_HOLD`
- no silent Python escape hatch

### 2. `tests/kernel/test_substrate_readiness.py`
Adds unit tests for:
- ready graph returns `READY`
- missing core tool returns `HOLD`
- unsafe mutation is detected
- unwitnessed irreversible action is detected
- forbidden public tool set includes bridge/gateway/forge/vault/memory/canary/conformance

### 3. `docs/AGI_SUBSTRATE_READINESS_GATE.md`
Operator-facing doctrine:

```text
No substrate proof, no AGI claim.
```

## Why this matters
This changes arifOS from architecture narrative into measurable substrate discipline.

The new standard becomes:

```text
init → observe → think → route → judge → act → seal
            ↓
substrate readiness must prove authority, evidence, mutation, and public-surface coherence
```

## Agent receipt
```yaml
agent_receipt:
  agent: ChatGPT_KERNEL_AGENT
  branch: feat/agi-substrate-readiness-gate
  files_changed:
    - arifosmcp/kernel/substrate_readiness.py
    - tests/kernel/test_substrate_readiness.py
    - docs/AGI_SUBSTRATE_READINESS_GATE.md
  invariant_target: measurable AGI-substrate readiness without AGI overclaim
  tests_added:
    - test_substrate_readiness_returns_report_shape
    - test_substrate_readiness_detects_missing_core_tool
    - test_substrate_readiness_blocks_unsafe_mutation
    - test_substrate_readiness_blocks_unwitnessed_irreversible_action
    - test_forbidden_public_tool_set_names_sovereign_machinery
  tests_run:
    command: not_run_by_connector
    result: hold
  risks:
    - default graph may currently return HOLD if arif_act/arif_seal capability metadata lacks irreversible/externality fields
    - this is correct: the gate should expose that gap rather than hide it
  did_not_touch:
    - forge execution
    - seal ledger
    - memory persistence
    - deployment
    - main branch
  verdict: READY_FOR_REVIEW
```

Relates to #526.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readiness check that evaluates system capabilities and returns a clear `READY` or `HOLD` result with a score and check-by-check report.
  * Added a documented readiness policy outlining the conditions required before advanced execution is considered admissible.

* **Tests**
  * Added coverage for ready and failing capability setups, including missing core tools, unsafe mutation behavior, and irreversible-action safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->