### PR TITLE
fix(kernel): GET /mcp returns 200 discovery JSON instead of 405

### DIFF
--- a/arifosmcp/server.py
+++ b/arifosmcp/server.py
@@ -374,7 +374,15 @@ class StatelessGetRejectMiddleware(BaseHTTPMiddleware):
     GET at the gateway layer before it reaches the SDK's SSE handler,
     forcing clients to use POST for JSON-RPC calls.
 
-    Clients receiving 405 will know to retry with POST.
+    SEP-2026-08-11 (discovery-friendly HOLD): the original 405 was
+    constitutionally correct but broke naive GET-probing clients (some
+    MCP inspectors try a GET before falling back to POST, per MCP's
+    optional-SSE-stream convention, and treat any non-200 as a hard
+    connection failure rather than reading the JSON-RPC hint body).
+    This now answers GET with HTTP 200 and a static discovery payload —
+    it NEVER opens a real SSE stream and NEVER reaches the SDK's SSE
+    handler, so the PHOENIX-73C protection is unchanged. Only the status
+    code and body shape changed, to stop those clients from bailing.
     """
 
     async def dispatch(self, request: Request, call_next):
@@ -382,21 +390,25 @@ class StatelessGetRejectMiddleware(BaseHTTPMiddleware):
         if request.url.path.rstrip("/") == "/mcp" and request.method == "GET":
             return JSONResponse(
                 {
-                    "jsonrpc": "2.0",
-                    "error": {
-                        "code": -32005,
-                        "message": "Method not allowed in stateless mode. "
-                        "Use POST for JSON-RPC calls. "
-                        "SSE streams are not supported in stateless_http mode "
-                        "(PHOENIX-73C).",
-                        "data": {
-                            "hint": "Retry this request using POST with "
-                            '{"jsonrpc":"2.0","method":"...","params":{}}'
-                        },
-                    },
+                    "mcp_endpoint": "https://mcp.arif-fazil.com/mcp",
+                    "transport": "streamable-http",
+                    "server": "arifOS Constitutional Kernel",
+                    "note": "This server is stateless (PHOENIX-73C): it does not "
+                    "open a persistent GET/SSE stream. Send a POST JSON-RPC "
+                    'request, e.g. {"jsonrpc":"2.0","id":1,"method":"initialize",'
+                    '"params":{...}} or {"method":"tools/list"}. Real MCP clients '
+                    "(Claude Code, Claude Desktop, streamable-http clients) do "
+                    "this automatically; select 'Streamable HTTP' transport, "
+                    "not legacy 'SSE', in inspector-style clients.",
+                    "health": "https://arifos.arif-fazil.com/health",
+                    "manifest": "https://mcp.arif-fazil.com/.well-known/mcp/server.json",
+                    "doctrine": "DITEMPA BUKAN DIBERI",
                 },
-                status_code=405,
-                headers={"Allow": "POST, DELETE"},
+                status_code=200,
+                headers={
+                    "Accept-Post": "application/json, text/event-stream",
+                    "Cache-Control": "no-cache, no-store, must-revalidate",
+                },
             )
         return await call_next(request)
 


### PR DESCRIPTION
## What
`StatelessGetRejectMiddleware` (PHOENIX-73C) still fully blocks GET from ever reaching the SDK's SSE handler — the protection against the concurrent-client singleton-stream 409 conflict is **unchanged**. Only the response to GET `/mcp` changes: 405 + JSON-RPC error body → 200 + a static discovery payload (endpoint, note to POST, health, manifest links). No SSE stream is ever opened by this handler in either version.

## Why
Diagnosed live against `https://mcp.arif-fazil.com/mcp`:
- `POST /mcp` (initialize) → 200, correct result, 8 tools, works fine.
- `GET /mcp` (with or without `Accept: text/event-stream`) → 405 regardless.

Naive MCP client probes (e.g. inspector-style tools that try GET before falling back to POST, per MCP's optional-SSE-stream convention) treat any non-200 as a hard connection failure rather than reading the JSON-RPC hint body in the 405, and never reach the working POST path. This surfaced as a real connection failure report against the live kernel.

## Verification
Ran the proposed change past the live kernel's own `arif_judge` before writing it: `result.reasons: ["Action authorized under standard capability bounds."]`, `effective_verdict: HOLD` (correctly, since the call was anonymous — `authority.verdict: HOLD`, `may_mutate: false`, `reason_code: UNMEASURED_INPUT`). The kernel didn't object to the proposal; it correctly withheld mutation authority from an unauthenticated caller. This PR is the F13-authenticated path to actually apply it — not merging or deploying, leaving that to you.

Not merged. Docs/behavior-only, single file, additive middleware response change — no route/auth/session logic touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a discovery response for `GET /mcp`, including endpoint usage, health and manifest URLs, and service guidance.

* **Bug Fixes**
  * Updated `GET /mcp` to return a successful response instead of an HTTP 405 error.
  * Prevented GET requests from being routed to the SSE handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->