### PR TITLE
fix(kernel): add missing 2025-06-18 to SUPPORTED_PROTOCOL_VERSIONS

### DIFF
--- a/arifosmcp/runtime/mcp_transport_bridge.py
+++ b/arifosmcp/runtime/mcp_transport_bridge.py
@@ -49,6 +49,9 @@ SUPPORTED_PROTOCOL_VERSIONS: frozenset[str] = frozenset(
     {
         "2026-07-28",  # P1 STATELESS (2026-08-01): Stateless MCP 2.0 — SEP-2243 header routing
         "2025-11-25",
+        "2025-06-18",  # BUGFIX (2026-08-11): missing real spec version — every client that
+                       # sends MCP-Protocol-Version: 2025-06-18 (Claude Desktop's connector
+                       # included) hard-rejected with -32022 before reaching any other logic.
         "2025-03-26",
         "2024-11-05",
     }


### PR DESCRIPTION
One-line fix: `2025-06-18` (real, published MCP spec version) was missing from `SUPPORTED_PROTOCOL_VERSIONS`, so any client sending `MCP-Protocol-Version: 2025-06-18` — including Claude Desktop's own connector — was hard-rejected with `-32022 UnsupportedProtocolVersion` before reaching any other kernel logic.

Diagnosed live against `mcp.arif-fazil.com/mcp`. Not merged — leaving to F13 review per standing practice for kernel changes.