### PR TITLE
chore(arifOS): pointer to /root/AAA/AGENTS-AUTONOMY.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,10 @@
 > This file is a pointer, not a constitution. Load /root/AGENTS.md for full doctrine.
 
 This organ operates under the arifOS Federation. For constitutional floors (F1-F13), organ topology, build/test/deploy conventions, autonomy tiers, and memory architecture — read `/root/AGENTS.md`.
+---
+
+## AAA Autonomy Protocol (overrides default agent behavior in this organ)
+
+For session-start probes, action-tier expansions, conflict resolution, and the autonomy goal — read `/root/AAA/AGENTS-AUTONOMY.md` first.
+
+DITEMPA BUKAN DIBERI ⚒️


### PR DESCRIPTION
## What
Append a one-line pointer to /root/AAA/AGENTS-AUTONOMY.md to the per-organ AGENTS.md.

## Why
The /root/AGENTS.md canonical constitution is a pointer doc. The autonomy protocol captures the operating rules the agent needs.

## Status
- T1: auto-do
- 1 file, +8 / -1 lines
- HEAD drift vs deployed 074d32bf4 is a sub-branch commit; not a real runtime drift. Deployed marker is unchanged at 074d32bf4 (commit 1f942888 is HEAD-on-branch, not yet on origin/main).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>