### PR TITLE
fix(kernel): restore minimal-envelope/outputSchema contract + GET /mcp crash (E9 P0)

### DIFF
--- a/arifosmcp/runtime/mcp_transport_bridge.py
+++ b/arifosmcp/runtime/mcp_transport_bridge.py
@@ -165,8 +165,13 @@ class MCPProtocolVersionMiddleware(BaseHTTPMiddleware):
         # SEP-2575: server/discover MUST work without prior version negotiation.
         # Clients in "auto" mode probe server/discover to discover supported versions
         # BEFORE sending MCP-Protocol-Version. This intercept handles that case.
+        # Initialize for ALL methods — the post-dispatch initialize check below
+        # reads method/body unconditionally; without this, GET /mcp (SSE listen
+        # stream) crashed with UnboundLocalError (96 tracebacks/24h, E9 audit).
+        method: str | None = None
+        body: dict[str, Any] = {}
+        req_id: Any = None
         if request.method == "POST":
-            method: str | None = None
             body_bytes = await request.body()
             try:
                 body = json.loads(body_bytes.decode("utf-8") or "{}")

--- a/arifosmcp/runtime/public_registry.py
+++ b/arifosmcp/runtime/public_registry.py
@@ -336,7 +336,10 @@ def _tool_output_schema(name: str) -> dict[str, Any]:
             "tool": {"const": name},
             "result": _tool_result_schema(name),
             "meta": {"type": "object", "additionalProperties": True},
-            "delta_S": {"type": "number"},
+            # Producer doctrine (verbosity.py, F2): delta_S is ALWAYS emitted;
+            # explicit null = honest UNKNOWN (unmeasured). 2026-08-14 E9 audit:
+            # schema must accept that null instead of rejecting the envelope.
+            "delta_S": {"anyOf": [{"type": "number"}, {"type": "null"}]},
             "timestamp": {"type": "string"},
             "session_id": {"anyOf": [{"type": "string"}, {"type": "null"}]},
             "actor_id": {"anyOf": [{"type": "string"}, {"type": "null"}]},

--- a/arifosmcp/runtime/verbosity.py
+++ b/arifosmcp/runtime/verbosity.py
@@ -451,6 +451,69 @@ def trim_for_verbosity(response: Any, verbosity: str | None) -> Any:
             minimal["effective_verdict"] = "HOLD"
             minimal["canonical_verdict"] = "DENY"
 
+    # CONTRACT RESTORATION (2026-08-14, E9 audit): the advertised outputSchema
+    # (public_registry.py) requires result/meta/timestamp/output_policy/
+    # nine_signal/reasons on every response, but the minimal projection built
+    # its envelope from scratch and dropped them — validating MCP clients
+    # rejected every minimal response. Emit honest minimal forms here, AFTER
+    # verdict resolution so derived values reflect the final effective_verdict.
+    # Derived values are marked (reason=derived_from_verdict); never presented
+    # as measured (F2).
+    if not isinstance(minimal.get("result"), dict):
+        _res_src = response.get("result")
+        minimal["result"] = _res_src if isinstance(_res_src, dict) else {}
+    if not isinstance(minimal.get("reasons"), list):
+        minimal["reasons"] = []
+    if not isinstance(minimal.get("meta"), dict):
+        _meta_src = response.get("meta")
+        minimal["meta"] = _meta_src if isinstance(_meta_src, dict) else {}
+    if not minimal.get("timestamp"):
+        _ts = _lookup("timestamp")
+        if not _ts:
+            from datetime import datetime, timezone
+
+            _ts = datetime.now(timezone.utc).isoformat()
+        minimal["timestamp"] = _ts
+    if not minimal.get("output_policy"):
+        minimal["output_policy"] = _lookup("output_policy") or "minimal"
+    if not isinstance(minimal.get("nine_signal"), dict):
+        _ns_src = response.get("nine_signal")
+        _ov = _ns_src.get("overall") if isinstance(_ns_src, dict) else None
+        if isinstance(_ov, dict) and _ov.get("state") and _ov.get("en"):
+            # Compact carry: source nine_signal exists — keep overall only.
+            _carried = {
+                "state": str(_ov["state"]),
+                "en": str(_ov["en"]),
+                **({"reason": str(_ov["reason"])} if _ov.get("reason") else {}),
+            }
+            # W-03: drift is a hard floor — a green source nine_signal must
+            # not survive when the final verdict is HOLD (drift override above
+            # ran before this block, so guard here too).
+            _ev_carry = str(minimal.get("effective_verdict") or "").upper()
+            if _ev_carry in ("HOLD", "VOID") and _carried["state"] in ("SELAMAT", "SAFE"):
+                _carried = {
+                    "state": "RETAK",
+                    "en": "HOLDING",
+                    "reason": _carried.get("reason") or "verdict_floor_override",
+                }
+            minimal["nine_signal"] = {"overall": _carried}
+        else:
+            # No measured nine_signal in source — derive a declared projection
+            # from the final verdict (same mapping precedent as the drift
+            # override above) or admit UNKNOWN. Never fabricate a measurement.
+            _ev9 = str(
+                minimal.get("effective_verdict") or minimal.get("verdict") or ""
+            ).upper()
+            if _ev9 in ("SEAL", "PROCEED", "OK", "COMPLETED"):
+                _st9, _en9 = "SELAMAT", "SAFE"
+            elif _ev9 in ("HOLD", "VOID", "SABAR"):
+                _st9, _en9 = "RETAK", "HOLDING"
+            else:
+                _st9, _en9 = "UNKNOWN", "UNMEASURED"
+            minimal["nine_signal"] = {
+                "overall": {"state": _st9, "en": _en9, "reason": "derived_from_verdict"}
+            }
+
     # F11 SAFETY NET: audit fields must survive. If call_hash missing, keep
     # trimmed form with whatever we have — returning full 12KB response was
     # worse entropy than a compact envelope missing one optional field.


### PR DESCRIPTION
## E9 audit repair — P0 source fixes (ARIF-authorized T2)

Found by 333-AGI investigation, independently verified by 555-ASI, during the E9 deployment-drift audit.

### P0-1 — Envelope contract restoration
Every minimal-verbosity MCP response failed client-side outputSchema validation: the projection in `verbosity.py` built its envelope from scratch and dropped `result/meta/timestamp/output_policy/nine_signal/reasons`, all required by the advertised schema in `public_registry.py`; `delta_S: null` (honest UNKNOWN per producer doctrine) also violated `type: number`.

**Fix:** minimal projection now emits the required fields. Derived `nine_signal` is explicitly marked `reason=derived_from_verdict` (a declared projection, never a fabricated measurement, F2). W-03 drift floor guarded: a green source `nine_signal` cannot survive a HOLD verdict. Schema side: `delta_S` accepts null (explicit null = honest UNKNOWN).

**Note:** redeploy alone would NOT have fixed this — the contradiction existed identically at HEAD.

### P0-2 — GET /mcp 500 crash
`mcp_transport_bridge.py` bound `method`/`body`/`req_id` only inside the POST branch, but the post-dispatch initialize check reads them unconditionally → `UnboundLocalError` on every GET /mcp (SSE listen stream). **96 tracebacks in 24h** in arifos.service journal. Also present at HEAD.

**Fix:** initialize all three before the POST guard.

### Verification
- `jsonschema.validate` of trimmed minimal envelope against advertised schema: **PASS**
- Drift-floor override (green source nine_signal under drift → RETAK/HOLDING): **PASS**
- GET /mcp dispatch (mocked): 200 passthrough, no exception: **PASS**
- pytest verbosity/registry/bridge selection: 4 failures, all **pre-existing** (confirmed identical on stashed baseline) — zero introduced
- Repo LSP pre-commit gate: 3/3 clean

### Explicitly NOT in this PR
- `contracts/identity.py` phantom production edit (FI-010/agy/antigravity) — T3, awaiting ARIF's adjudication
- `arifosmcp/runtime/v2_envelope.py` — **foreign uncommitted change detected mid-session in the worktree** (unknown author, probable concurrent worker). Left untouched, uncommitted.
- Redeploy/restart of arifos.service — T3, sequenced after the identity ruling

DITEMPA BUKAN DIBERI ⚒️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed errors that could occur when handling GET and server-sent event requests.
  * Improved compatibility for tool results where `delta_S` is explicitly `null`.
  * Ensured minimal-verbosity responses consistently include required result, reasoning, metadata, timestamp, policy, and signal information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->