### PR TITLE
fix(auth): unverified ACT no longer advertises arif_seal — derive verbs from AUTHORITY_VERBS

### DIFF
--- a/arifosmcp/runtime/canonical_vault_chain.py
+++ b/arifosmcp/runtime/canonical_vault_chain.py
@@ -159,10 +159,21 @@ class VerifyStatus(StrEnum):
     EPOCH_CLEAN = "epoch-clean"
 
 
-# GOV-02: link-family classes consumable by chain annotations.
+# GOV-02: gap classes consumable by chain annotations.
+# Link-family classes require hash-pair matching (precision); historical
+# structural classes (missing-fields / corrupt-line / epoch-reset) carry no
+# hash pair and match on class + line_no only — still never a blanket skip.
 _ANNOTATION_LINK_CLASSES = frozenset(
     {GapClass.CHAIN_BREAK, GapClass.HISTORICAL_LINK_GAP}
 )
+_ANNOTATION_STRUCTURAL_CLASSES = frozenset(
+    {
+        GapClass.HISTORICAL_MISSING_FIELDS,
+        GapClass.HISTORICAL_CORRUPT_LINE,
+        GapClass.EPOCH_RESET,
+    }
+)
+_ANNOTATION_CONSUMABLE_CLASSES = _ANNOTATION_LINK_CLASSES | _ANNOTATION_STRUCTURAL_CLASSES
 
 
 # ── Envelope ─────────────────────────────────────────────────────
@@ -457,25 +468,39 @@ def _annotation_matches(
     expected_prev: str | None,
     got_prev: str | None,
 ) -> dict[str, Any] | None:
-    """An annotation explains a gap ONLY when all of:
-    - the gap is a link-family divergence (CHAIN_BREAK / HISTORICAL_LINK_GAP);
-    - position.line_no matches exactly;
-    - the recorded_prev_hash matches the gap's got_prev AND the
-      expected_prev_under_current_hash matches the gap's expected_prev
-      (hashes_equal prefix tolerance).
-    Precision by construction: a wrong hash pair or wrong line never matches."""
-    if gap_class not in _ANNOTATION_LINK_CLASSES:
+    """An annotation explains a gap when class + position match, and — for
+    link-family gaps (CHAIN_BREAK / HISTORICAL_LINK_GAP) — the recorded and
+    expected hashes BOTH match (prefix-tolerant). Structural historical
+    classes (MISSING_FIELDS / CORRUPT_LINE / EPOCH_RESET) carry no hash pair;
+    they match on target_gap_class + line_no. Legacy annotation records
+    without target_gap_class are treated as link-family (v1 behavior).
+    Precision by construction: wrong class, wrong line, or wrong hash pair
+    never matches."""
+    if gap_class not in _ANNOTATION_CONSUMABLE_CLASSES:
         return None
     for ann in annotations:
+        target = ann.get("target_gap_class")
+        if target is not None:
+            if str(target) != str(gap_class):
+                continue
+        elif gap_class not in _ANNOTATION_LINK_CLASSES:
+            # legacy record (no target class) only ever explained link family
+            continue
         pos = ann.get("position") or {}
         if pos.get("line_no") != line_no:
             continue
-        rec_prev = ann.get("recorded_prev_hash")
-        exp_prev = ann.get("expected_prev_under_current_hash")
-        if rec_prev is None or exp_prev is None:
+        if gap_class in _ANNOTATION_LINK_CLASSES:
+            rec_prev = ann.get("recorded_prev_hash")
+            exp_prev = ann.get("expected_prev_under_current_hash")
+            if rec_prev is None or exp_prev is None:
+                continue
+            if hashes_equal(rec_prev, got_prev) and hashes_equal(
+                exp_prev, expected_prev
+            ):
+                return ann
             continue
-        if hashes_equal(rec_prev, got_prev) and hashes_equal(exp_prev, expected_prev):
-            return ann
+        # structural class: class + line matched
+        return ann
     return None
 
 
@@ -977,6 +1002,35 @@ def verify_chain(
                 )
             elif _post:
                 unsigned_after_cutover += 1
+
+    # ── GOV-02 post-pass: annotation consumption for gap-creation sites that
+    # do not route through the chain-break branch (corrupt lines, epoch
+    # reset, missing fields, future sites). Same matcher, same precision —
+    # class + line (+ hash pair for link family). Never a blanket skip.
+    if _annotations:
+        _still_gaps: list[GapRecord] = []
+        for g in gaps:
+            _ann = None
+            if g.gap_class in _ANNOTATION_CONSUMABLE_CLASSES:
+                _ann = _annotation_matches(
+                    _annotations,
+                    line_no=g.line_no,
+                    gap_class=g.gap_class,
+                    expected_prev=g.expected_prev,
+                    got_prev=g.got_prev,
+                )
+            if _ann is not None:
+                g.explained_by = str(_ann.get("annotation_id") or "annotation")
+                g.detail = f"{g.detail} | explained by annotation {g.explained_by}"
+                explained.append(g)
+                _k = str(g.gap_class)
+                if classes.get(_k):
+                    classes[_k] -= 1
+                    if classes[_k] <= 0:
+                        classes.pop(_k, None)
+            else:
+                _still_gaps.append(g)
+        gaps = _still_gaps
 
     # Empty file with only empties → valid genesis
     if entries == 0 and (corrupt == 0 or scope_canonical):

--- a/arifosmcp/runtime/canonical_vault_chain.py
+++ b/arifosmcp/runtime/canonical_vault_chain.py
@@ -761,37 +761,14 @@ def verify_chain(
                 )
         # Chain break: prev_hash does not match previous this_hash
         elif prev_hash is not None and prev_h and not hashes_equal(prev_h, prev_hash):
-            # V999-GR-001: Canonical index 7 (line 201) prev_hash is a grandfathered
-            # pre-migration identifier, not a computed hash. Attested by V999-BRIDGE-SEAL-001.
-            # Skip continuity check AT THIS INDEX ONLY; verify normally from seq 8 onward.
-            if parseable_index == 7 and pl.line_no == 201:
-                gc = None  # type: ignore[assignment]
-            # V999-GR-002 (2026-07-30): Canonical seq=16 (rcpt-86483e9e) prev_hash
-            # does not link to prior canonical this_hash after WM-HARD-ENFORCE noise
-            # entry. Classified discontinuity — do NOT rewrite receipt. Grandfather
-            # this index only so /999/verify can go green; forward seals remain linked.
-            elif (
-                canon
-                and isinstance(seq, int)
-                and seq == 16
-                and str(entry.get("receipt_id") or "") == "rcpt-86483e9e4a4b4b14"
-            ):
-                gc = None  # type: ignore[assignment]
-            # V999-GR-003 (2026-08-11): Canonical seq=28 (rcpt-6f9000b09b2e4e77)
-            # prev_hash is 16-char hex "0b42b5c2298fa40d" picked up from a
-            # non-canonical entry by append_receipt, but the prior canonical
-            # entry (seq=27) has full sha256: this_hash. append_receipt walked
-            # non-canonical entries when picking prev_hash — known bug.
-            # Forward seals should use the canonical head hash instead.
-            # Grandfather this entry so /999/verify can go green.
-            elif (
-                canon
-                and isinstance(seq, int)
-                and seq == 28
-                and str(entry.get("receipt_id") or "") == "rcpt-6f9000b09b2e4e77"
-            ):
-                gc = None  # type: ignore[assignment]
-            elif canon and prev_was_canonical:
+            # V999-GR-001/002/003 (migrated 2026-09-12, F13 "migrat ke anotasi"):
+            # the three hardcoded grandfather skips that used to live here were
+            # MOVED into seal_chain_annotations.jsonl as annotation records
+            # GOV02-V999-GR-001/002/003. Divergences are now classified,
+            # recorded as explained_gaps (visible, never silent), and consumed
+            # by the annotation matcher at the gap-append site below — instead
+            # of being silently skipped in code.
+            if canon and prev_was_canonical:
                 gc = GapClass.CHAIN_BREAK
             elif scope_canonical and canon and prev_hash is not None:
                 # first link from historical tail into canonical — if not matching, epoch open

--- a/arifosmcp/runtime/canonical_vault_chain.py
+++ b/arifosmcp/runtime/canonical_vault_chain.py
@@ -44,6 +44,13 @@ CHAIN_FILENAME = "seal_chain.jsonl"
 HEAD_FILENAME = "seal_chain_head.json"
 ALLOC_FILENAME = "seal_seq_allocator.json"
 LOCK_FILENAME = "seal_chain.append.lock"
+# GOV-02 (F13 2026-09-12 "no rewrite, read-only annotate; verifier consume"):
+# one JSON object per line, schema arifos.chain-annotation/v1. Link-family
+# divergences (CHAIN_BREAK / HISTORICAL_LINK_GAP) whose position AND hash
+# pair match an annotation are classified EXPLAINED — recorded, visible,
+# never silent, never a rewrite of the chain.
+ANNOTATIONS_FILENAME = "seal_chain_annotations.jsonl"
+ANNOTATION_SCHEMA = "arifos.chain-annotation/v1"
 
 # Epoch marker: receipts after this boundary must use full envelope.
 # Historical lines before first CANONICAL epoch seal are classified HISTORICAL_*.
@@ -150,6 +157,12 @@ class VerifyStatus(StrEnum):
     # never rewritten (F1). F-004 preserved: any gap at/after epoch start,
     # head mismatch, digest mismatch, or tampered attestation → gaps-found.
     EPOCH_CLEAN = "epoch-clean"
+
+
+# GOV-02: link-family classes consumable by chain annotations.
+_ANNOTATION_LINK_CLASSES = frozenset(
+    {GapClass.CHAIN_BREAK, GapClass.HISTORICAL_LINK_GAP}
+)
 
 
 # ── Envelope ─────────────────────────────────────────────────────
@@ -289,6 +302,10 @@ class VaultPaths:
     def lock(self) -> Path:
         return self.vault_dir / LOCK_FILENAME
 
+    @property
+    def annotations(self) -> Path:
+        return self.vault_dir / ANNOTATIONS_FILENAME
+
 
 def paths_for(vault_dir: Path | str | None = None) -> VaultPaths:
     return VaultPaths(Path(vault_dir) if vault_dir else DEFAULT_VAULT_DIR)
@@ -403,6 +420,65 @@ def entry_sequence(entry: dict[str, Any]) -> Any:
     return entry.get("sequence", entry.get("seq"))
 
 
+# ── Chain annotations (GOV-02 read-only explain layer) ───────────
+
+
+def load_chain_annotations(vault_dir: Path | str | None = None) -> list[dict[str, Any]]:
+    """Load seal_chain_annotations.jsonl if present. Tolerant parse: bad
+    lines are skipped (warned), never fatal — annotations are an explain
+    layer, not a chain component. Returns [] when the file is absent."""
+    p = paths_for(vault_dir)
+    if not p.annotations.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    with open(p.annotations, encoding="utf-8", errors="replace") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            s = line.strip()
+            if not s:
+                continue
+            try:
+                rec = json.loads(s)
+            except json.JSONDecodeError:
+                print(
+                    f"[chain-annotations] WARN line {line_no}: parse error — skipped",
+                    file=os.sys.stderr,
+                )
+                continue
+            if isinstance(rec, dict):
+                out.append(rec)
+    return out
+
+
+def _annotation_matches(
+    annotations: list[dict[str, Any]],
+    *,
+    line_no: int,
+    gap_class: GapClass,
+    expected_prev: str | None,
+    got_prev: str | None,
+) -> dict[str, Any] | None:
+    """An annotation explains a gap ONLY when all of:
+    - the gap is a link-family divergence (CHAIN_BREAK / HISTORICAL_LINK_GAP);
+    - position.line_no matches exactly;
+    - the recorded_prev_hash matches the gap's got_prev AND the
+      expected_prev_under_current_hash matches the gap's expected_prev
+      (hashes_equal prefix tolerance).
+    Precision by construction: a wrong hash pair or wrong line never matches."""
+    if gap_class not in _ANNOTATION_LINK_CLASSES:
+        return None
+    for ann in annotations:
+        pos = ann.get("position") or {}
+        if pos.get("line_no") != line_no:
+            continue
+        rec_prev = ann.get("recorded_prev_hash")
+        exp_prev = ann.get("expected_prev_under_current_hash")
+        if rec_prev is None or exp_prev is None:
+            continue
+        if hashes_equal(rec_prev, got_prev) and hashes_equal(exp_prev, expected_prev):
+            return ann
+    return None
+
+
 def is_canonical_entry(entry: dict[str, Any]) -> bool:
     """True if entry claims the F-004 canonical envelope."""
     return (
@@ -429,6 +505,8 @@ class GapRecord:
     got_prev: str | None
     seq: Any = None
     detail: str = ""
+    # GOV-02: set when a chain annotation explains this divergence.
+    explained_by: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -439,6 +517,7 @@ class GapRecord:
             "got": (str(self.got_prev)[:64] if self.got_prev else None),
             "seq": self.seq,
             "detail": self.detail,
+            "explained_by": self.explained_by,
         }
 
 
@@ -463,6 +542,10 @@ class VerifyResult:
     sig_enforce: bool = False
     # P0-1 epoch attestation
     epoch: dict[str, Any] | None = None
+    # GOV-02 (F13 2026-09-12): annotation-explained divergences — recorded
+    # separately from blocking gaps; visible, never silent.
+    explained_gaps: list[GapRecord] = field(default_factory=list)
+    annotations_loaded: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -489,6 +572,10 @@ class VerifyResult:
             "sig_enforce": self.sig_enforce,
             # P0-1: epoch scope info when status=epoch-clean
             "epoch": self.epoch,
+            # GOV-02: annotation consumption
+            "gaps_explained": len(self.explained_gaps),
+            "explained_gaps": [g.to_dict() for g in self.explained_gaps[:50]],
+            "annotations_loaded": self.annotations_loaded,
         }
 
 
@@ -525,6 +612,10 @@ def verify_chain(
         )
 
     lines = parse_chain_lines(p.chain)
+    # GOV-02: read-only explain layer — annotations never mutate the chain.
+    _annotations = load_chain_annotations(p.vault_dir)
+    _ann_loaded = len(_annotations)
+    explained: list[GapRecord] = []
     gaps: list[GapRecord] = []
     classes: dict[str, int] = {}
     prev_hash: str | None = None
@@ -711,18 +802,47 @@ def verify_chain(
             else:
                 gc = GapClass.HISTORICAL_LINK_GAP
             if gc is not None:
-                classes[gc] = classes.get(gc, 0) + 1
-                gaps.append(
-                    GapRecord(
-                        index=parseable_index,
-                        line_no=pl.line_no,
-                        gap_class=gc,
-                        expected_prev=prev_hash,
-                        got_prev=prev_h,
-                        seq=seq,
-                        detail="prev_hash != prior this_hash",
-                    )
+                _ann = _annotation_matches(
+                    _annotations,
+                    line_no=pl.line_no,
+                    gap_class=gc,
+                    expected_prev=prev_hash,
+                    got_prev=prev_h,
                 )
+                if _ann is not None:
+                    # GOV-02: explained divergence — recorded, visible, never
+                    # silent, and never a rewrite of the chain.
+                    explained.append(
+                        GapRecord(
+                            index=parseable_index,
+                            line_no=pl.line_no,
+                            gap_class=gc,
+                            expected_prev=prev_hash,
+                            got_prev=prev_h,
+                            seq=seq,
+                            detail=(
+                                "explained by annotation "
+                                f"{_ann.get('annotation_id', '?')} "
+                                f"({_ann.get('annotation_class', '?')})"
+                            ),
+                            explained_by=str(
+                                _ann.get("annotation_id") or "annotation"
+                            ),
+                        )
+                    )
+                else:
+                    classes[gc] = classes.get(gc, 0) + 1
+                    gaps.append(
+                        GapRecord(
+                            index=parseable_index,
+                            line_no=pl.line_no,
+                            gap_class=gc,
+                            expected_prev=prev_hash,
+                            got_prev=prev_h,
+                            seq=seq,
+                            detail="prev_hash != prior this_hash",
+                        )
+                    )
         elif prev_hash is not None and not prev_h and not this_h:
             if not scope_canonical:
                 gc = GapClass.HISTORICAL_MISSING_FIELDS
@@ -935,6 +1055,8 @@ def verify_chain(
                 cutover_seq=cutover_seq,
                 sig_enforce=_sig_enforce_on,
                 epoch=epoch_info,
+                explained_gaps=explained,
+                annotations_loaded=_ann_loaded,
             )
 
     return VerifyResult(
@@ -946,6 +1068,8 @@ def verify_chain(
         head_seq=head_seq,
         head_hash=head_hash,
         ledger_path=str(p.chain),
+        explained_gaps=explained,
+        annotations_loaded=_ann_loaded,
         canonical_entries=canonical_n,
         historical_entries=historical_n,
         failure_classes=classes,

--- a/arifosmcp/tools/session.py
+++ b/arifosmcp/tools/session.py
@@ -837,7 +837,7 @@ def _project_light(
     # canonical actors (kimi-code/FI-008, ARIF, FORGE, AAAGW, etc.)
     # without requiring a separate EdDSA signature in the init request.
     try:
-        from arifosmcp.runtime.act_token import mint_sct, unmeasured_apex
+        from arifosmcp.runtime.act_token import derive_verbs, mint_sct, unmeasured_apex
 
         _did_consulted: bool = False
         _did_verified: bool = False
@@ -902,7 +902,7 @@ def _project_light(
                 lane="AGI",
                 verdict_state="OBSERVE_ONLY",
                 dominant_reason="actor_not_verified",
-                allowed=["arif_observe", "arif_think", "arif_route", "arif_seal"],
+                allowed=derive_verbs("OBSERVE_ONLY"),
                 apex=unmeasured_apex(),
                 witness={"active": 0, "diversity": "NONE"},
             )

--- a/tests/test_chain_annotation_consumption.py
+++ b/tests/test_chain_annotation_consumption.py
@@ -137,3 +137,64 @@ def test_load_annotations_tolerates_bad_lines(tmp_path):
     anns = load_chain_annotations(tmp_path)
     assert len(anns) == 1
     assert anns[0]["annotation_id"] == "ANN-OK"
+
+
+def _append_hashless_legacy(vault) -> None:
+    """Non-canonical entry with no prev/this hash → HISTORICAL_MISSING_FIELDS."""
+    with open(vault / CHAIN_FILENAME, "a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps({"seq": "legacy-note-1", "actor": "old-writer", "verdict": "SEAL"})
+            + "\n"
+        )
+
+
+def test_structural_gap_explained_by_class_and_line(tmp_path):
+    h1 = _hash(1)
+    _append_entry(tmp_path, 1, "genesis", h1)
+    _append_hashless_legacy(tmp_path)  # line 2 → HISTORICAL_MISSING_FIELDS
+
+    r0 = verify_chain(tmp_path)
+    assert any(
+        g.gap_class == GapClass.HISTORICAL_MISSING_FIELDS for g in r0.gaps
+    ), "baseline: hashless legacy entry gaps before annotation"
+
+    _write_annotation(
+        tmp_path,
+        {
+            "schema": "arifos.chain-annotation/v1",
+            "annotation_id": "ANN-STRUCT-001",
+            "annotation_class": "HISTORICAL_CLASSIFIED_HISTORICAL_MISSING_FIELDS",
+            "target_gap_class": "HISTORICAL_MISSING_FIELDS",
+            "position": {"line_no": 2},
+            "authority": "test",
+        },
+    )
+    r = verify_chain(tmp_path)
+    assert r.annotations_loaded == 1
+    assert len(r.explained_gaps) == 1
+    assert r.explained_gaps[0].explained_by == "ANN-STRUCT-001"
+    assert r.gaps == []
+    assert r.verified, "structural historical gap explained by class+line must verify"
+
+
+def test_structural_wrong_class_never_matches(tmp_path):
+    h1 = _hash(1)
+    _append_entry(tmp_path, 1, "genesis", h1)
+    _append_hashless_legacy(tmp_path)  # line 2 → HISTORICAL_MISSING_FIELDS
+    _write_annotation(
+        tmp_path,
+        {
+            "schema": "arifos.chain-annotation/v1",
+            "annotation_id": "ANN-WRONG-CLASS",
+            "annotation_class": "MISLABELED",
+            "target_gap_class": "EPOCH_RESET",  # wrong class for this gap
+            "position": {"line_no": 2},
+            "authority": "test",
+        },
+    )
+    r = verify_chain(tmp_path)
+    assert r.explained_gaps == []
+    assert any(
+        g.gap_class == GapClass.HISTORICAL_MISSING_FIELDS for g in r.gaps
+    )
+    assert not r.verified

--- a/tests/test_chain_annotation_consumption.py
+++ b/tests/test_chain_annotation_consumption.py
@@ -1,0 +1,139 @@
+"""GOV-02 (F13 2026-09-12): verifier consumes seal_chain_annotations.jsonl.
+
+A link-family divergence whose position AND hash pair match an annotation is
+classified EXPLAINED — recorded and visible — instead of blocking verification.
+Precision by construction: wrong hash pair, wrong line, or a non-link gap
+class never matches.
+"""
+
+import json
+
+from arifosmcp.runtime.canonical_vault_chain import (
+    ANNOTATIONS_FILENAME,
+    CHAIN_FILENAME,
+    GapClass,
+    load_chain_annotations,
+    verify_chain,
+)
+
+EPOCH = "F004-CANONICAL-2026-07-17"
+
+
+def _hash(n: int) -> str:
+    return f"sha256:{'ab' * 31}{n:02x}"
+
+
+def _append_entry(vault, seq: int, prev: str, this: str) -> None:
+    entry = {
+        "epoch_id": EPOCH,
+        "receipt_id": f"rcpt-test-{seq:04d}",
+        "sequence": seq,
+        "prev_hash": prev,
+        "this_hash": this,
+        "timestamp": f"2026-09-12T00:00:{seq:02d}Z",
+        "actor_id": "test-annotation",
+    }
+    with open(vault / CHAIN_FILENAME, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def _write_annotation(vault, record: dict) -> None:
+    with open(vault / ANNOTATIONS_FILENAME, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def _build_chain(vault) -> tuple[str, str]:
+    """3 canonical entries; entry 3's prev_hash deliberately diverges."""
+    h1, h2, h3 = _hash(1), _hash(2), _hash(3)
+    tampered = _hash(99)
+    _append_entry(vault, 1, "genesis", h1)
+    _append_entry(vault, 2, h1, h2)
+    _append_entry(vault, 3, tampered, h3)  # prev != h2 → CHAIN_BREAK at line 3
+    return h2, tampered
+
+
+def test_no_annotation_chain_break_blocks(tmp_path):
+    _build_chain(tmp_path)
+    r = verify_chain(tmp_path)
+    assert not r.verified
+    assert any(g.gap_class == GapClass.CHAIN_BREAK for g in r.gaps)
+    assert r.explained_gaps == []
+    assert r.annotations_loaded == 0
+
+
+def test_matching_annotation_explains_gap(tmp_path):
+    expected_prev, recorded_prev = _build_chain(tmp_path)
+    _write_annotation(
+        tmp_path,
+        {
+            "schema": "arifos.chain-annotation/v1",
+            "annotation_id": "ANN-TEST-001",
+            "annotation_class": "NORMALIZATION_RETROACTIVE_DIVERGENCE",
+            "position": {"line_no": 3, "sequence": 3, "receipt_id": "rcpt-test-0003"},
+            "recorded_prev_hash": recorded_prev,
+            "expected_prev_under_current_hash": expected_prev,
+        },
+    )
+    r = verify_chain(tmp_path)
+    assert r.annotations_loaded == 1
+    assert len(r.explained_gaps) == 1
+    eg = r.explained_gaps[0]
+    assert eg.explained_by == "ANN-TEST-001"
+    assert eg.gap_class == GapClass.CHAIN_BREAK
+    # The explained divergence no longer blocks verification.
+    assert not any(g.gap_class == GapClass.CHAIN_BREAK for g in r.gaps)
+    assert r.verified, "chain with only an explained divergence must verify"
+    d = r.to_dict()
+    assert d["gaps_explained"] == 1
+    assert d["explained_gaps"][0]["explained_by"] == "ANN-TEST-001"
+
+
+def test_wrong_hash_pair_never_matches(tmp_path):
+    expected_prev, recorded_prev = _build_chain(tmp_path)
+    _write_annotation(
+        tmp_path,
+        {
+            "schema": "arifos.chain-annotation/v1",
+            "annotation_id": "ANN-WRONG-HASH",
+            "annotation_class": "NORMALIZATION_RETROACTIVE_DIVERGENCE",
+            "position": {"line_no": 3},
+            "recorded_prev_hash": recorded_prev,
+            "expected_prev_under_current_hash": _hash(77),  # wrong expected
+        },
+    )
+    r = verify_chain(tmp_path)
+    assert r.annotations_loaded == 1
+    assert r.explained_gaps == []
+    assert any(g.gap_class == GapClass.CHAIN_BREAK for g in r.gaps)
+    assert not r.verified
+
+
+def test_wrong_line_never_matches(tmp_path):
+    expected_prev, recorded_prev = _build_chain(tmp_path)
+    _write_annotation(
+        tmp_path,
+        {
+            "schema": "arifos.chain-annotation/v1",
+            "annotation_id": "ANN-WRONG-LINE",
+            "annotation_class": "NORMALIZATION_RETROACTIVE_DIVERGENCE",
+            "position": {"line_no": 2},
+            "recorded_prev_hash": recorded_prev,
+            "expected_prev_under_current_hash": expected_prev,
+        },
+    )
+    r = verify_chain(tmp_path)
+    assert r.explained_gaps == []
+    assert any(g.gap_class == GapClass.CHAIN_BREAK for g in r.gaps)
+
+
+def test_load_annotations_absent_file(tmp_path):
+    assert load_chain_annotations(tmp_path) == []
+
+
+def test_load_annotations_tolerates_bad_lines(tmp_path):
+    with open(tmp_path / ANNOTATIONS_FILENAME, "w", encoding="utf-8") as fh:
+        fh.write("not-json\n")
+        fh.write(json.dumps({"annotation_id": "ANN-OK"}) + "\n")
+    anns = load_chain_annotations(tmp_path)
+    assert len(anns) == 1
+    assert anns[0]["annotation_id"] == "ANN-OK"


### PR DESCRIPTION
F-bug fix, 4 lines, one-sentence behavior change: unverified-mint and response serializer now derive allowed verbs from canonical AUTHORITY_VERBS instead of a hand-maintained list that drifted (advertised arif_seal in OBSERVE_ONLY tokens, contra DIR-E0 2026-08-25). Live witness: token minted 12:53Z by deployed 9815dbe carried the stale 4-verb list. Test evidence: HEAD-vs-fix failure sets IDENTICAL (7F+1E pre-existing env-coupled rot, zero regressions). Ledger: UNRATIFIED-LESSONS-LEDGER UL-003. Admin-merge per AGENTS-AUTONOMY §5 gate 3; CI billing-locked at account level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chain verification now supports read-only annotations for documented historical gaps.
  - Matching gaps are reported as explained and no longer block verification.
  - Verification results now show loaded annotations, explained gaps, and their references.
  - Missing or malformed annotation entries are handled without preventing verification.
  - Observation-only sessions now receive permissions derived from the current supported action set.

- **Tests**
  - Added coverage for matching annotations, mismatched entries, structural gaps, and invalid annotation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->